### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   pip-audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hatamirais/dinkes-farmalkes-ims/security/code-scanning/1](https://github.com/hatamirais/dinkes-farmalkes-ims/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained regardless of repository/org defaults.

Best single fix (without changing functionality): in `.github/workflows/dependency-audit.yml`, add a top-level `permissions` section after the `on:` block and before `jobs:`:

- `contents: read`

This is sufficient for `actions/checkout` and read-only audit execution. No imports, methods, or external definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
