### PR TITLE
Potential fix for code scanning alert no. 2: URL redirection from remote source

### DIFF
--- a/backend/apps/items/views.py
+++ b/backend/apps/items/views.py
@@ -4,6 +4,7 @@ from django.contrib import messages
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.http import JsonResponse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_POST
 
 from apps.core.decorators import perm_required
@@ -22,7 +23,11 @@ from .forms import ItemForm, UnitForm, CategoryForm, ProgramForm
 
 def _redirect_next_or_default(request, fallback_url_name):
     next_url = request.POST.get("next") or request.GET.get("next")
-    if next_url:
+    if next_url and url_has_allowed_host_and_scheme(
+        url=next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
         return redirect(next_url)
     return redirect(fallback_url_name)
 


### PR DESCRIPTION
Potential fix for [https://github.com/hatamirais/dinkes-farmalkes-ims/security/code-scanning/2](https://github.com/hatamirais/dinkes-farmalkes-ims/security/code-scanning/2)

Use Django’s built-in URL safety check before redirecting user-provided `next` values.

Best fix in this file:
- Import `url_has_allowed_host_and_scheme` from `django.utils.http`.
- In `_redirect_next_or_default`, only redirect to `next_url` if it passes `url_has_allowed_host_and_scheme` with `allowed_hosts={request.get_host()}` and `require_https=request.is_secure()`.
- Otherwise, fall back to `redirect(fallback_url_name)` exactly as today.

This preserves existing behavior for valid in-app redirects while blocking external/malicious redirect targets, and it addresses all 3 alert variants because they all flow through the same helper.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
