### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/backend/static/js/app.js
+++ b/backend/static/js/app.js
@@ -484,6 +484,7 @@ function initStockCardSearch() {
 
             const a = document.createElement('a');
             const detailUrl = buildDetailUrl(item.id);
+            a.href = window.location.origin;
             a.pathname = detailUrl.pathname;
             a.search = detailUrl.search;
             a.hash = detailUrl.hash;

--- a/backend/static/js/app.js
+++ b/backend/static/js/app.js
@@ -393,7 +393,8 @@ function initStockCardSearch() {
     if (!searchInput || !searchResults) return;
 
     const searchUrl = searchInput.getAttribute('data-search-url') || '/stock/api/item-search/';
-    const rawDetailTemplate = searchInput.getAttribute('data-detail-template') || '/stock/stock-card/0/';
+    const defaultDetailTemplate = '/stock/stock-card/0/';
+    const rawDetailTemplate = searchInput.getAttribute('data-detail-template') || defaultDetailTemplate;
     const getSafeDetailTemplate = (template) => {
         try {
             const candidate = new URL(template, window.location.origin);
@@ -406,19 +407,29 @@ function initStockCardSearch() {
         } catch (e) {
             // Fall through to default template.
         }
-        return '/stock/stock-card/0/';
+        return defaultDetailTemplate;
     };
     const detailTemplate = getSafeDetailTemplate(rawDetailTemplate);
     let debounceTimer = null;
     let activeIndex = -1;
 
     const buildDetailUrl = (id) => {
-        const detailUrl = new URL(detailTemplate, window.location.origin);
-        detailUrl.pathname = detailUrl.pathname.replace(
-            /\/0\/?$/,
-            `/${encodeURIComponent(String(id))}/`
-        );
-        return `${detailUrl.pathname}${detailUrl.search}${detailUrl.hash}`;
+        try {
+            const detailUrl = new URL(detailTemplate, window.location.origin);
+            if (
+                detailUrl.origin !== window.location.origin ||
+                !/\/0\/?$/.test(detailUrl.pathname)
+            ) {
+                return defaultDetailTemplate.replace(/0\/?$/, `${encodeURIComponent(String(id))}/`);
+            }
+            detailUrl.pathname = detailUrl.pathname.replace(
+                /\/0\/?$/,
+                `/${encodeURIComponent(String(id))}/`
+            );
+            return `${detailUrl.pathname}${detailUrl.search}${detailUrl.hash}`;
+        } catch (e) {
+            return defaultDetailTemplate.replace(/0\/?$/, `${encodeURIComponent(String(id))}/`);
+        }
     };
 
     const getResultItems = () => Array.from(searchResults.querySelectorAll('.search-result-item'));

--- a/backend/static/js/app.js
+++ b/backend/static/js/app.js
@@ -412,7 +412,14 @@ function initStockCardSearch() {
     let debounceTimer = null;
     let activeIndex = -1;
 
-    const buildDetailUrl = (id) => detailTemplate.replace(/0\/?$/, `${encodeURIComponent(String(id))}/`);
+    const buildDetailUrl = (id) => {
+        const detailUrl = new URL(detailTemplate, window.location.origin);
+        detailUrl.pathname = detailUrl.pathname.replace(
+            /\/0\/?$/,
+            `/${encodeURIComponent(String(id))}/`
+        );
+        return `${detailUrl.pathname}${detailUrl.search}${detailUrl.hash}`;
+    };
 
     const getResultItems = () => Array.from(searchResults.querySelectorAll('.search-result-item'));
 

--- a/backend/static/js/app.js
+++ b/backend/static/js/app.js
@@ -393,11 +393,26 @@ function initStockCardSearch() {
     if (!searchInput || !searchResults) return;
 
     const searchUrl = searchInput.getAttribute('data-search-url') || '/stock/api/item-search/';
-    const detailTemplate = searchInput.getAttribute('data-detail-template') || '/stock/stock-card/0/';
+    const rawDetailTemplate = searchInput.getAttribute('data-detail-template') || '/stock/stock-card/0/';
+    const getSafeDetailTemplate = (template) => {
+        try {
+            const candidate = new URL(template, window.location.origin);
+            const isHttp = candidate.protocol === 'http:' || candidate.protocol === 'https:';
+            const isSameOrigin = candidate.origin === window.location.origin;
+            const hasPlaceholder = /\/0\/?$/.test(candidate.pathname);
+            if (isHttp && isSameOrigin && hasPlaceholder) {
+                return `${candidate.pathname}${candidate.search}${candidate.hash}`;
+            }
+        } catch (e) {
+            // Fall through to default template.
+        }
+        return '/stock/stock-card/0/';
+    };
+    const detailTemplate = getSafeDetailTemplate(rawDetailTemplate);
     let debounceTimer = null;
     let activeIndex = -1;
 
-    const buildDetailUrl = (id) => detailTemplate.replace(/0\/?$/, `${id}/`);
+    const buildDetailUrl = (id) => detailTemplate.replace(/0\/?$/, `${encodeURIComponent(String(id))}/`);
 
     const getResultItems = () => Array.from(searchResults.querySelectorAll('.search-result-item'));
 

--- a/backend/static/js/app.js
+++ b/backend/static/js/app.js
@@ -394,13 +394,14 @@ function initStockCardSearch() {
 
     const searchUrl = searchInput.getAttribute('data-search-url') || '/stock/api/item-search/';
     const defaultDetailTemplate = '/stock/stock-card/0/';
+    const detailTemplatePathPattern = /\/0\/?$/;
     const rawDetailTemplate = searchInput.getAttribute('data-detail-template') || defaultDetailTemplate;
     const getSafeDetailTemplate = (template) => {
         try {
             const candidate = new URL(template, window.location.origin);
             const isHttp = candidate.protocol === 'http:' || candidate.protocol === 'https:';
             const isSameOrigin = candidate.origin === window.location.origin;
-            const hasPlaceholder = /\/0\/?$/.test(candidate.pathname);
+            const hasPlaceholder = detailTemplatePathPattern.test(candidate.pathname);
             if (isHttp && isSameOrigin && hasPlaceholder) {
                 return `${candidate.pathname}${candidate.search}${candidate.hash}`;
             }
@@ -416,7 +417,7 @@ function initStockCardSearch() {
     const buildDefaultDetailUrl = (id) => {
         const detailUrl = new URL(defaultDetailTemplate, window.location.origin);
         detailUrl.pathname = detailUrl.pathname.replace(
-            /\/0\/?$/,
+            detailTemplatePathPattern,
             `/${encodeURIComponent(String(id))}/`
         );
         return detailUrl;
@@ -427,12 +428,12 @@ function initStockCardSearch() {
             const detailUrl = new URL(detailTemplate, window.location.origin);
             if (
                 detailUrl.origin !== window.location.origin ||
-                !/\/0\/?$/.test(detailUrl.pathname)
+                !detailTemplatePathPattern.test(detailUrl.pathname)
             ) {
                 return buildDefaultDetailUrl(id);
             }
             detailUrl.pathname = detailUrl.pathname.replace(
-                /\/0\/?$/,
+                detailTemplatePathPattern,
                 `/${encodeURIComponent(String(id))}/`
             );
             return detailUrl;
@@ -484,10 +485,7 @@ function initStockCardSearch() {
 
             const a = document.createElement('a');
             const detailUrl = buildDetailUrl(item.id);
-            a.href = window.location.origin;
-            a.pathname = detailUrl.pathname;
-            a.search = detailUrl.search;
-            a.hash = detailUrl.hash;
+            a.href = detailUrl.href;
             a.className = 'search-result-item';
 
             const row = document.createElement('div');

--- a/backend/static/js/app.js
+++ b/backend/static/js/app.js
@@ -413,6 +413,15 @@ function initStockCardSearch() {
     let debounceTimer = null;
     let activeIndex = -1;
 
+    const buildDefaultDetailUrl = (id) => {
+        const detailUrl = new URL(defaultDetailTemplate, window.location.origin);
+        detailUrl.pathname = detailUrl.pathname.replace(
+            /\/0\/?$/,
+            `/${encodeURIComponent(String(id))}/`
+        );
+        return detailUrl;
+    };
+
     const buildDetailUrl = (id) => {
         try {
             const detailUrl = new URL(detailTemplate, window.location.origin);
@@ -420,15 +429,15 @@ function initStockCardSearch() {
                 detailUrl.origin !== window.location.origin ||
                 !/\/0\/?$/.test(detailUrl.pathname)
             ) {
-                return defaultDetailTemplate.replace(/0\/?$/, `${encodeURIComponent(String(id))}/`);
+                return buildDefaultDetailUrl(id);
             }
             detailUrl.pathname = detailUrl.pathname.replace(
                 /\/0\/?$/,
                 `/${encodeURIComponent(String(id))}/`
             );
-            return `${detailUrl.pathname}${detailUrl.search}${detailUrl.hash}`;
+            return detailUrl;
         } catch (e) {
-            return defaultDetailTemplate.replace(/0\/?$/, `${encodeURIComponent(String(id))}/`);
+            return buildDefaultDetailUrl(id);
         }
     };
 
@@ -474,7 +483,10 @@ function initStockCardSearch() {
             const stockText = `Stok: ${item.stock ?? 0} ${item.satuan || ''}`;
 
             const a = document.createElement('a');
-            a.href = buildDetailUrl(item.id);
+            const detailUrl = buildDetailUrl(item.id);
+            a.pathname = detailUrl.pathname;
+            a.search = detailUrl.search;
+            a.hash = detailUrl.hash;
             a.className = 'search-result-item';
 
             const row = document.createElement('div');


### PR DESCRIPTION
Potential fix for [https://github.com/hatamirais/dinkes-farmalkes-ims/security/code-scanning/9](https://github.com/hatamirais/dinkes-farmalkes-ims/security/code-scanning/9)

The best fix is to stop trusting `data-detail-template` as-is and enforce a safe URL template policy before using it.  
Specifically in `backend/static/js/app.js` around lines 395–401:

- Read the raw attribute as before.
- Normalize/validate it so only same-origin HTTP(S) path templates are accepted.
- Ensure the template contains a numeric placeholder (`0` segment) and reject anything else.
- Fall back to a known-safe default (`/stock/stock-card/0/`) when invalid.
- Build the final URL using `encodeURIComponent(String(id))` before replacement.

This preserves existing functionality (configurable template + id substitution) while preventing dangerous schemes or malformed templates from being written into `a.href`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
