### PR TITLE
feat(users): responsive mobile cards, CSV export, keyboard shortcuts

### DIFF
--- a/backend/apps/users/urls.py
+++ b/backend/apps/users/urls.py
@@ -7,6 +7,7 @@ app_name = "users"
 urlpatterns = [
     path("", views.user_list, name="user_list"),
     path("create/", views.user_create, name="user_create"),
+    path("export/", views.user_export_csv, name="user_export_csv"),
     path("bulk-action/", views.user_bulk_action, name="user_bulk_action"),
     path("<int:pk>/", views.user_detail, name="user_detail"),
     path("<int:pk>/edit/", views.user_update, name="user_update"),

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -468,10 +468,11 @@ def user_export_csv(request):
 
     def generate_rows():
         writer = csv.writer(_Echo())
-        yield writer.writerow([
+        header_row = writer.writerow([
             "Username", "Nama Lengkap", "NIP", "Email",
             "Jabatan", "Fasilitas", "Status", "Login Terakhir",
         ])
+        yield f"\ufeff{header_row}"
         for user in queryset.iterator(chunk_size=200):
             yield writer.writerow([
                 user.username,
@@ -488,7 +489,7 @@ def user_export_csv(request):
 
     response = StreamingHttpResponse(
         generate_rows(),
-        content_type="text/csv; charset=utf-8-sig",
+        content_type="text/csv; charset=utf-8",
     )
     response["Content-Disposition"] = 'attachment; filename="users_export.csv"'
     return response

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -1,3 +1,5 @@
+import csv
+
 from django.contrib import messages
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.decorators import login_required
@@ -5,7 +7,7 @@ from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.db.models import ProtectedError
-from django.http import JsonResponse
+from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 
 from .access import ROLE_DEFAULT_SCOPES, has_module_scope
@@ -415,3 +417,78 @@ def user_reset_password(request, pk):
         request, f"Password untuk {target_user.username} berhasil direset."
     )
     return redirect("users:user_update", pk=pk)
+
+
+class _Echo:
+    """Object that implements just the write method of the file-like interface."""
+
+    def write(self, value):
+        return value
+
+
+def _build_user_export_queryset(request):
+    queryset = User.objects.select_related("facility").only(
+        "username", "full_name", "nip", "email", "role",
+        "is_active", "last_login", "facility",
+    )
+
+    search = request.GET.get("q", "").strip()
+    if search:
+        queryset = (
+            queryset.filter(username__icontains=search)
+            | queryset.filter(full_name__icontains=search)
+            | queryset.filter(email__icontains=search)
+        )
+
+    jabatan = request.GET.get("jabatan", "").strip()
+    if not jabatan:
+        jabatan = request.GET.get("role", "").strip()
+    if jabatan:
+        queryset = queryset.filter(role=jabatan)
+
+    active = request.GET.get("active", "1")
+    if active == "1":
+        queryset = queryset.filter(is_active=True)
+    elif active == "0":
+        queryset = queryset.filter(is_active=False)
+
+    return queryset.order_by("-date_joined")
+
+
+@login_required
+def user_export_csv(request):
+    if not _can_view_users(request.user):
+        return _forbidden_manage_user(
+            request,
+            "Anda tidak memiliki izin untuk mengekspor data pengguna.",
+        )
+
+    queryset = _build_user_export_queryset(request)
+    role_map = dict(User.Role.choices)
+
+    def generate_rows():
+        writer = csv.writer(_Echo())
+        yield writer.writerow([
+            "Username", "Nama Lengkap", "NIP", "Email",
+            "Jabatan", "Fasilitas", "Status", "Login Terakhir",
+        ])
+        for user in queryset.iterator(chunk_size=200):
+            yield writer.writerow([
+                user.username,
+                user.full_name,
+                user.nip,
+                user.email,
+                role_map.get(user.role, user.role),
+                user.facility.name if user.facility else (
+                    "Instalasi Farmasi" if user.role != "PUSKESMAS" else ""
+                ),
+                "Aktif" if user.is_active else "Nonaktif",
+                user.last_login.strftime("%Y-%m-%d %H:%M") if user.last_login else "",
+            ])
+
+    response = StreamingHttpResponse(
+        generate_rows(),
+        content_type="text/csv; charset=utf-8-sig",
+    )
+    response["Content-Disposition"] = 'attachment; filename="users_export.csv"'
+    return response

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -468,11 +468,11 @@ def user_export_csv(request):
 
     def generate_rows():
         writer = csv.writer(_Echo())
-        header_row = writer.writerow([
+        yield "\ufeff"
+        yield writer.writerow([
             "Username", "Nama Lengkap", "NIP", "Email",
             "Jabatan", "Fasilitas", "Status", "Login Terakhir",
         ])
-        yield f"\ufeff{header_row}"
         for user in queryset.iterator(chunk_size=200):
             yield writer.writerow([
                 user.username,

--- a/backend/static/css/style.css
+++ b/backend/static/css/style.css
@@ -1586,3 +1586,21 @@ body {
 .strength-bar.fair { width: 50%; background: #f59e0b; }
 .strength-bar.good { width: 75%; background: #3b82f6; }
 .strength-bar.strong { width: 100%; background: #22c55e; }
+
+/* ===== Mobile User Cards ===== */
+.user-card-mobile {
+    background: #fff;
+    transition: background 0.15s;
+}
+
+.user-card-mobile:hover {
+    background: #f8fafc;
+}
+
+.user-card-mobile:last-child {
+    border-bottom: none !important;
+}
+
+.user-card-mobile .dropdown-toggle::after {
+    display: none;
+}

--- a/backend/static/js/user-form.js
+++ b/backend/static/js/user-form.js
@@ -307,4 +307,16 @@ document.addEventListener('DOMContentLoaded', function () {
 
     syncFacilityField();
     updateDeviationDots();
+
+    // ── Keyboard shortcut: Esc to go back to user list ──────────────
+    document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape' && !e.target.closest('.modal') && !e.target.closest('input,textarea,select')) {
+            var backLink = document.querySelector('.navbar-left-tools a[href*="/users/"]') ||
+                           document.querySelector('a[href*="/users/"]');
+            if (backLink) {
+                e.preventDefault();
+                window.location.href = backLink.href;
+            }
+        }
+    });
 });

--- a/backend/static/js/user-list.js
+++ b/backend/static/js/user-list.js
@@ -193,4 +193,15 @@ document.addEventListener('DOMContentLoaded', function () {
                 });
         });
     });
+
+    // ── Keyboard shortcut: Alt+N to create user ────────────────────
+    document.addEventListener('keydown', function (e) {
+        if (e.altKey && e.key === 'n') {
+            e.preventDefault();
+            var createBtn = document.getElementById('createUserBtn');
+            if (createBtn) {
+                window.location.href = createBtn.href;
+            }
+        }
+    });
 });

--- a/backend/templates/users/user_detail.html
+++ b/backend/templates/users/user_detail.html
@@ -17,6 +17,9 @@
                     </span>
                     <h5 class="mt-2 mb-1">{{ target_user.full_name|default:target_user.username }}</h5>
                     <code>{{ target_user.username }}</code>
+                    <button type="button" class="btn btn-sm btn-link text-muted p-0 ms-1 copy-btn" data-copy="{{ target_user.username }}" title="Salin username">
+                        <i class="bi bi-clipboard"></i>
+                    </button>
                     <div class="mt-2">
                         <span class="badge badge-role-{{ target_user.role|lower }}">{{ target_user.get_role_display }}</span>
                         {% if target_user.is_active %}
@@ -32,7 +35,10 @@
                     <dd class="col-sm-8">{{ target_user.nip|default:'-' }}</dd>
 
                     <dt class="col-sm-4 text-muted">Email</dt>
-                    <dd class="col-sm-8">{{ target_user.email|default:'-' }}</dd>
+                    <dd class="col-sm-8">
+                        {{ target_user.email|default:'-' }}
+                        {% if target_user.email %}<button type="button" class="btn btn-sm btn-link text-muted p-0 ms-1 copy-btn" data-copy="{{ target_user.email }}" title="Salin email"><i class="bi bi-clipboard"></i></button>{% endif %}
+                    </dd>
 
                     <dt class="col-sm-4 text-muted">Fasilitas</dt>
                     <dd class="col-sm-8">
@@ -118,4 +124,25 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.querySelectorAll('.copy-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+        var text = this.getAttribute('data-copy');
+        navigator.clipboard.writeText(text).then(function() {
+            var icon = btn.querySelector('i');
+            icon.className = 'bi bi-check text-success';
+            setTimeout(function() { icon.className = 'bi bi-clipboard'; }, 1500);
+        }).catch(function() {});
+    });
+});
+
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && !e.target.closest('input,textarea,select')) {
+        window.location.href = '{% url "users:user_list" %}';
+    }
+});
+</script>
 {% endblock %}

--- a/backend/templates/users/user_list.html
+++ b/backend/templates/users/user_list.html
@@ -12,8 +12,11 @@
             {% if total_count %}
             <span class="badge bg-light text-dark border me-1">{{ total_count }} pengguna</span>
             {% endif %}
+            <a href="{% url 'users:user_export_csv' %}?{{ filter_params }}" class="btn btn-outline-secondary btn-sm" title="Ekspor ke CSV" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Ekspor hasil filter ke CSV">
+                <i class="bi bi-download me-1"></i>Export
+            </a>
             {% if can_add_user %}
-            <a href="{% url 'users:user_create' %}" class="btn btn-primary btn-sm">
+            <a href="{% url 'users:user_create' %}" class="btn btn-primary btn-sm" id="createUserBtn">
                 <i class="bi bi-plus-lg me-1"></i>Tambah Pengguna
             </a>
             {% endif %}
@@ -65,7 +68,7 @@
         {% csrf_token %}
         <input type="hidden" name="action" value="" id="bulkActionField">
 
-        <div class="table-responsive">
+        <div class="table-responsive d-none d-md-block">
             <table class="table">
                 <thead>
                     <tr>
@@ -211,6 +214,71 @@
             </table>
         </div>
     </form>
+
+    <!-- Mobile card layout (visible only on small screens) -->
+    <div class="d-md-none">
+        {% for account in users %}
+        <div class="user-card-mobile border-bottom p-3">
+            <div class="d-flex align-items-start justify-content-between">
+                <div class="d-flex align-items-center gap-2">
+                    {% if can_change_user %}
+                    <input type="checkbox" class="form-check-input user-checkbox" name="selected_users" value="{{ account.pk }}" form="bulkActionForm">
+                    {% endif %}
+                    <span class="avatar-circle avatar-sm" data-initial="{{ account.full_name|slice:':1'|default:account.username|slice:':1' }}">{{ account.full_name|slice:':1'|default:account.username|slice:':1'|upper }}</span>
+                    <div>
+                        <a href="{% url 'users:user_detail' account.pk %}" class="fw-semibold text-decoration-none">{{ account.username }}</a>
+                        {% if account.full_name %}<div class="small text-muted">{{ account.full_name }}</div>{% endif %}
+                    </div>
+                </div>
+                <div class="d-flex align-items-center gap-1">
+                    <span class="badge badge-role-{{ account.role|lower }}">{{ account.get_role_display }}</span>
+                    {% if can_change_user %}
+                    <div class="form-check form-switch active-toggle-switch ms-1 mb-0">
+                        <input class="form-check-input user-active-toggle" type="checkbox" role="switch"
+                            data-pk="{{ account.pk }}"
+                            data-url="{% url 'users:user_toggle_active' account.pk %}"
+                            {% if account.is_active %}checked{% endif %}
+                            {% if request.user == account %}disabled{% endif %}>
+                    </div>
+                    {% endif %}
+                    <div class="dropdown">
+                        <button class="btn btn-sm btn-outline-secondary border-0" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-three-dots-vertical"></i>
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-end">
+                            <li><a class="dropdown-item" href="{% url 'users:user_detail' account.pk %}"><i class="bi bi-eye me-2"></i>Lihat Detail</a></li>
+                            {% if can_change_user %}
+                            <li><a class="dropdown-item" href="{% url 'users:user_update' account.pk %}"><i class="bi bi-pencil me-2"></i>Edit</a></li>
+                            {% endif %}
+                            {% if can_delete_user %}
+                            <li><hr class="dropdown-divider"></li>
+                            <li><button type="button" class="dropdown-item text-danger single-delete-btn"
+                                data-delete-url="{% url 'users:user_delete' account.pk %}"
+                                data-username="{{ account.username }}"
+                                {% if request.user == account or account.is_active %}disabled{% endif %}>
+                                <i class="bi bi-trash me-2"></i>Hapus
+                            </button></li>
+                            {% endif %}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            <div class="row mt-2 small text-muted">
+                <div class="col-6">
+                    {% if account.facility %}{{ account.facility.name }}{% elif account.role == 'PUSKESMAS' %}Belum diatur{% else %}Instalasi Farmasi{% endif %}
+                </div>
+                <div class="col-6 text-end">
+                    {% if account.last_login %}{{ account.last_login|timesince }} lalu{% else %}Belum pernah{% endif %}
+                </div>
+            </div>
+        </div>
+        {% empty %}
+        <div class="empty-state">
+            <i class="bi bi-person-lines-fill d-block"></i>
+            <p>Belum ada data pengguna</p>
+        </div>
+        {% endfor %}
+    </div>
 
     {% if users.has_other_pages %}
     <div class="d-flex justify-content-between align-items-center px-3 py-2 border-top">


### PR DESCRIPTION
- Phase 3: Responsive table & mobile UX (#36)
  - Mobile card layout replacing table on <md breakpoint
  - Action kebab dropdown (...) on mobile rows
  - Inline active-toggle switch on mobile cards
  - Hide desktop table on mobile, show cards only on mobile
  - user-card-mobile CSS with hover state

- Phase 3: Export & keyboard shortcuts (#37)
  - CSV export endpoint (/users/export/) respecting current filters
  - StreamingHttpResponse with BOM for Excel compatibility
  - 'Export' download button on list header
  - Alt+N keyboard shortcut to navigate to create user
  - Esc keyboard shortcut on form/detail pages to return to list
  - Copy-to-clipboard buttons on username and email in detail page
  - Green checkmark feedback for 1.5s after copy

Closes #36, closes #37

# Pull Request

## Summary

-

## Testing

- [ ] Tests run locally (or explain why not)

## Documentation and release checklist

- [ ] Docs updated when models/routes/settings/scripts changed (`README.md`, `AGENTS.md`, `SYSTEM_MODEL.md`, `docs/developer_guide.md`, `backend/seed/README.md` as needed)
- [ ] If release-impacting, `VERSION` and `CHANGELOG.md` are updated in this PR
