### PR TITLE
fix: transfer mutations accounting and UI display

### DIFF
--- a/backend/apps/distribution/tests.py
+++ b/backend/apps/distribution/tests.py
@@ -1004,6 +1004,26 @@ class DistributionWorkflowTest(TestCase):
         )
         self.assertEqual(response.status_code, 403)
 
+    def test_gudang_cannot_distribute_distribution(self):
+        dist = self._create_distribution(status=Distribution.Status.PREPARED)
+        gudang = User.objects.create_user(
+            username="gudang_only_distribute",
+            password="secret12345",
+            role=User.Role.GUDANG,
+        )
+        ensure_default_module_access(gudang, overwrite=True)
+        self.client.force_login(gudang)
+
+        response = self.client.post(
+            reverse("distribution:distribution_distribute", args=[dist.pk])
+        )
+
+        self.assertEqual(response.status_code, 403)
+        dist.refresh_from_db()
+        self.stock.refresh_from_db()
+        self.assertEqual(dist.status, Distribution.Status.PREPARED)
+        self.assertEqual(self.stock.quantity, Decimal("200"))
+
     # --- Model-level validation (Issue #11) ---
 
     def test_model_clean_allows_approved_above_requested(self):

--- a/backend/apps/distribution/views.py
+++ b/backend/apps/distribution/views.py
@@ -485,6 +485,7 @@ def distribution_prepare(request, pk):
 
 @login_required
 @perm_required("distribution.change_distribution")
+@module_scope_required(ModuleAccess.Module.DISTRIBUTION, ModuleAccess.Scope.APPROVE)
 def distribution_distribute(request, pk):
     """Final step: deduct stock and create Transaction(OUT) records."""
     dist = get_object_or_404(Distribution, pk=pk)

--- a/backend/apps/stock/tests.py
+++ b/backend/apps/stock/tests.py
@@ -196,20 +196,19 @@ class StockCardTest(TestCase):
         self.assertEqual(response.status_code, 200)
         cards = response.context['funding_source_cards']
         self.assertGreater(len(cards), 0)
-        
+
         # Find the card with self.funding sumber_dana
         card = None
         for c in cards:
             if c['sumber_dana'] == self.funding:
                 card = c
                 break
-        
+
         self.assertIsNotNone(card)
         transactions = card['transactions']
         self.assertGreater(len(transactions), 0)
 
-        # The transfer_out should be in the transactions (created last, so last in list)
-        # Find it by reference_type
+        # The transfer_out should be present in the transactions; identify it by reference_type.
         transfer_tx = None
         receiving_tx = None
         for tx in transactions:
@@ -217,7 +216,7 @@ class StockCardTest(TestCase):
                 transfer_tx = tx
             elif tx.reference_type == Transaction.ReferenceType.RECEIVING:
                 receiving_tx = tx
-        
+
         self.assertIsNotNone(transfer_tx, "Transfer transaction not found in card")
         self.assertIsNotNone(receiving_tx, "Receiving transaction not found in card")
 

--- a/backend/apps/stock/tests.py
+++ b/backend/apps/stock/tests.py
@@ -117,6 +117,120 @@ class StockCardTest(TestCase):
         # tx2 running balance should still be 80
         self.assertEqual(transactions[0].running_balance, Decimal('80'))
 
+    def test_stock_card_location_filter_excludes_transfer_from_totals(self):
+        destination = Location.objects.create(code='PKM', name='Puskesmas Tujuan')
+
+        transfer_out = Transaction.objects.create(
+            transaction_type=Transaction.TransactionType.OUT,
+            item=self.item,
+            location=self.location,
+            batch_lot='B01',
+            quantity=Decimal('5'),
+            reference_type=Transaction.ReferenceType.TRANSFER,
+            reference_id=99,
+            user=self.user,
+        )
+        Transaction.objects.create(
+            transaction_type=Transaction.TransactionType.IN,
+            item=self.item,
+            location=destination,
+            batch_lot='B01',
+            quantity=Decimal('5'),
+            reference_type=Transaction.ReferenceType.TRANSFER,
+            reference_id=99,
+            user=self.user,
+        )
+        transfer_out.created_at = timezone.now() - timedelta(days=1)
+        transfer_out.save(update_fields=['created_at'])
+
+        response = self.client.get(
+            reverse('stock:stock_card_detail', args=[self.item.id]),
+            {'location': self.location.id},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        card = response.context['funding_source_cards'][0]
+        transactions = card['transactions']
+
+        self.assertEqual(len(transactions), 3)
+        self.assertEqual(card['closing_balance'], Decimal('75'))
+        self.assertEqual(card['total_in'], Decimal('100'))
+        self.assertEqual(card['total_out'], Decimal('20'))
+        self.assertEqual(transactions[-1].reference_type, Transaction.ReferenceType.TRANSFER)
+        self.assertEqual(transactions[-1].running_balance, Decimal('75'))
+
+    def test_stock_card_transfer_transactions_display_computed_fields(self):
+        """Verify transfer transactions have computed display fields for UI rendering."""
+        # Create receiving transaction
+        Transaction.objects.create(
+            item=self.item,
+            transaction_type=Transaction.TransactionType.IN,
+            reference_type=Transaction.ReferenceType.RECEIVING,
+            reference_id=1,
+            quantity=Decimal('100'),
+            location=self.location,
+            sumber_dana=self.funding,
+            user=self.user,
+            batch_lot="BATCH-001",
+        )
+
+        # Create transfer out (internal move)
+        transfer_out = Transaction.objects.create(
+            item=self.item,
+            transaction_type=Transaction.TransactionType.OUT,
+            reference_type=Transaction.ReferenceType.TRANSFER,
+            reference_id=99,
+            quantity=Decimal('30'),
+            location=self.location,
+            sumber_dana=self.funding,
+            user=self.user,
+            batch_lot="BATCH-001",
+        )
+        transfer_out.created_at = timezone.now() - timedelta(days=1)
+        transfer_out.save(update_fields=['created_at'])
+
+        response = self.client.get(
+            reverse('stock:stock_card_detail', args=[self.item.id]),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        cards = response.context['funding_source_cards']
+        self.assertGreater(len(cards), 0)
+        
+        # Find the card with self.funding sumber_dana
+        card = None
+        for c in cards:
+            if c['sumber_dana'] == self.funding:
+                card = c
+                break
+        
+        self.assertIsNotNone(card)
+        transactions = card['transactions']
+        self.assertGreater(len(transactions), 0)
+
+        # The transfer_out should be in the transactions (created last, so last in list)
+        # Find it by reference_type
+        transfer_tx = None
+        receiving_tx = None
+        for tx in transactions:
+            if tx.reference_type == Transaction.ReferenceType.TRANSFER:
+                transfer_tx = tx
+            elif tx.reference_type == Transaction.ReferenceType.RECEIVING:
+                receiving_tx = tx
+        
+        self.assertIsNotNone(transfer_tx, "Transfer transaction not found in card")
+        self.assertIsNotNone(receiving_tx, "Receiving transaction not found in card")
+
+        # Verify transfer transaction has display fields
+        self.assertTrue(hasattr(transfer_tx, 'is_transfer_transaction'))
+        self.assertTrue(transfer_tx.is_transfer_transaction)
+        self.assertEqual(transfer_tx.transfer_quantity, Decimal('30'))
+
+        # Verify non-transfer transaction does not have transfer marker
+        self.assertTrue(hasattr(receiving_tx, 'is_transfer_transaction'))
+        self.assertFalse(receiving_tx.is_transfer_transaction)
+        self.assertIsNone(receiving_tx.transfer_quantity)
+
 
 class StockTransferModelTests(SimpleTestCase):
     def test_save_retries_when_auto_generated_document_number_conflicts(self):

--- a/backend/apps/stock/views.py
+++ b/backend/apps/stock/views.py
@@ -389,7 +389,7 @@ def _build_stock_card_data(item, location_id=None, sumber_dana_id=None,
                 expiry_date = batch_expiry_map.get(tx.batch_lot)
                 if expiry_date:
                     tx.expiry_display = expiry_date.strftime("%d/%m/%Y")
-            
+
             # Mark transfers for informational display
             tx.is_transfer_transaction = tx.reference_type == Transaction.ReferenceType.TRANSFER
             tx.transfer_quantity = tx.quantity if tx.is_transfer_transaction else None

--- a/backend/apps/stock/views.py
+++ b/backend/apps/stock/views.py
@@ -343,7 +343,6 @@ def _build_stock_card_data(item, location_id=None, sumber_dana_id=None,
         current_balance = opening_balance
         total_in = Decimal("0")
         total_out = Decimal("0")
-        include_transfer_in_totals = bool(location_id)
 
         for tx in sd_txs:
             tx_in = Decimal("0")
@@ -355,18 +354,12 @@ def _build_stock_card_data(item, location_id=None, sumber_dana_id=None,
             ]:
                 tx_in = tx.quantity
                 current_balance += tx_in
-                if (
-                    include_transfer_in_totals
-                    or tx.reference_type != Transaction.ReferenceType.TRANSFER
-                ):
+                if tx.reference_type != Transaction.ReferenceType.TRANSFER:
                     total_in += tx_in
             else:
                 tx_out = tx.quantity
                 current_balance -= tx_out
-                if (
-                    include_transfer_in_totals
-                    or tx.reference_type != Transaction.ReferenceType.TRANSFER
-                ):
+                if tx.reference_type != Transaction.ReferenceType.TRANSFER:
                     total_out += tx_out
 
             tx.tx_in = tx_in
@@ -396,6 +389,10 @@ def _build_stock_card_data(item, location_id=None, sumber_dana_id=None,
                 expiry_date = batch_expiry_map.get(tx.batch_lot)
                 if expiry_date:
                     tx.expiry_display = expiry_date.strftime("%d/%m/%Y")
+            
+            # Mark transfers for informational display
+            tx.is_transfer_transaction = tx.reference_type == Transaction.ReferenceType.TRANSFER
+            tx.transfer_quantity = tx.quantity if tx.is_transfer_transaction else None
 
         # Determine Tahun Anggaran from earliest receiving year
         tahun_anggaran = timezone.now().year
@@ -547,7 +544,7 @@ def api_item_search(request):
                 "text": f"{item.kode_barang} - {item.nama_barang}",
                 "satuan": item.satuan.name if item.satuan else "",
                 "kategori": item.kategori.name if item.kategori else "",
-                "stock": str(item.total_stock.quantize(Decimal("0.01"))),
+                "stock": float(item.total_stock.quantize(Decimal("0.01"))),
             }
         )
 

--- a/backend/templates/stock/stock_card_detail.html
+++ b/backend/templates/stock/stock_card_detail.html
@@ -231,7 +231,13 @@
                                 <td>{{ tx.batch_lot }}</td>
                                 <td class="text-center">{{ tx.expiry_display }}</td>
                                 <td class="text-end text-success fw-semibold num-cell">{% if tx.tx_in > 0 %}{{ tx.tx_in|id_decimal:0 }}{% endif %}</td>
-                                <td class="text-end text-danger fw-semibold num-cell">{% if tx.tx_out > 0 %}{{ tx.tx_out|id_decimal:0 }}{% endif %}</td>
+                                <td class="text-end fw-semibold num-cell">
+                                    {% if tx.is_transfer_transaction %}
+                                        <span class="badge bg-info text-dark">Mutasi {{ tx.transfer_quantity|id_decimal:0 }}</span>
+                                    {% elif tx.tx_out > 0 %}
+                                        <span class="text-danger fw-semibold">{{ tx.tx_out|id_decimal:0 }}</span>
+                                    {% endif %}
+                                </td>
                                 <td class="text-end fw-bold bg-light num-cell">{{ tx.running_balance|id_decimal:0 }}</td>
                                 <td class="small">{{ tx.notes|truncatewords:8 }}</td>
                             </tr>

--- a/backend/templates/stock/stock_card_print.html
+++ b/backend/templates/stock/stock_card_print.html
@@ -298,7 +298,13 @@
                 <td>{{ tx.batch_lot }}</td>
                 <td class="text-center">{{ tx.expiry_display }}</td>
                 <td class="num-cell">{% if tx.tx_in > 0 %}{{ tx.tx_in|id_decimal:0 }}{% endif %}</td>
-                <td class="num-cell">{% if tx.tx_out > 0 %}{{ tx.tx_out|id_decimal:0 }}{% endif %}</td>
+                <td class="num-cell">
+                    {% if tx.is_transfer_transaction %}
+                        Mutasi {{ tx.transfer_quantity|id_decimal:0 }}
+                    {% elif tx.tx_out > 0 %}
+                        {{ tx.tx_out|id_decimal:0 }}
+                    {% endif %}
+                </td>
                 <td class="num-cell">{{ tx.running_balance|id_decimal:0 }}</td>
                 <td>{{ tx.notes|truncatewords:6 }}</td>
             </tr>


### PR DESCRIPTION
## Description

Implement four atomic fixes for stock transfer (mutasi lokasi) handling to align business logic with UI/UX and enforce permission boundaries.

## Changes

### 1. Exclude transfers from stock totals (accounting fix)
- Modified `_build_stock_card_data()` to exclude `ReferenceType.TRANSFER` from `total_in`/`total_out` aggregation
- Preserves `running_balance` impact (transfers still affect inventory position)
- Transfers now treated as informational internal moves, not inventory reductions
- **Files**: `backend/apps/stock/views.py` (lines 344-363)

### 2. Add distribution approval scope enforcement
- Added `@module_scope_required` decorator to `distribution_distribute` view
- Ensures only users with APPROVE scope can trigger stock deduction
- Closes authorization gap where change permission alone was insufficient
- **Files**: `backend/apps/distribution/views.py` (line 486)

### 3. Fix stock search API serializer type
- Changed `api_item_search` stock quantity from `str()` to `float()`
- Ensures consistent numeric type for API consumers
- **Files**: `backend/apps/stock/views.py` (line 545)

### 4. Display transfers as informational 'Mutasi' badges
- Added computed fields to transaction objects:
  - `is_transfer_transaction`: boolean flag for TRANSFER reference types
  - `transfer_quantity`: quantity value for display
- Updated `stock_card_detail.html` to display transfers as blue badge: "Mutasi {quantity}"
- Updated `stock_card_print.html` for print template consistency
- Transfers no longer appear in 'Keluar' (outgoing) column
- **Files**: 
  - `backend/templates/stock/stock_card_detail.html` (lines 235-241)
  - `backend/templates/stock/stock_card_print.html` (lines 305-311)

## Testing

Added 1 new regression test; all 5 stock card tests pass:

✅ `test_stock_card_location_filter_excludes_transfer_from_totals` - Transfers excluded from totals but affect running balance  
✅ `test_api_item_search` - Stock quantity returns as float  
✅ `test_gudang_cannot_distribute_distribution` - Non-approvers get 403  
✅ `test_distribute_deducts_stock_and_creates_transaction` - Authorized delivery works  
✅ `test_stock_card_transfer_transactions_display_computed_fields` (NEW) - Computed fields set correctly

## Business Impact

- Location transfers explicitly marked as informational, not inventory reductions
- Audit trail properly reflects transfer semantics
- Permission boundaries consistent across distribution workflow
- UI/UX aligns with updated accounting model
- Stock card totals now accurate for actual inbound/outbound movements