### PR TITLE
fix(stock): clarify stock card transfer semantics

### DIFF
--- a/backend/apps/stock/tests.py
+++ b/backend/apps/stock/tests.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from apps.users.models import User
 from apps.items.models import Unit, Category, Item, Location, FundingSource
 from apps.stock.models import Stock, StockTransfer, Transaction
+from apps.core.models import SystemSettings
 
 class StockCardTest(TestCase):
     def setUp(self):
@@ -31,6 +32,9 @@ class StockCardTest(TestCase):
         )
         self.location = Location.objects.create(code='GUDANG', name='Gudang Utama')
         self.funding = FundingSource.objects.create(code='APBD', name='APBD')
+        settings = SystemSettings.get_settings()
+        settings.facility_name = "Instalasi Farmasi"
+        settings.save()
 
         # Create transactions for testing running balance
         # TX 1: IN 100
@@ -119,6 +123,11 @@ class StockCardTest(TestCase):
 
     def test_stock_card_location_filter_excludes_transfer_from_totals(self):
         destination = Location.objects.create(code='PKM', name='Puskesmas Tujuan')
+        transfer = StockTransfer.objects.create(
+            source_location=self.location,
+            destination_location=destination,
+            created_by=self.user,
+        )
 
         transfer_out = Transaction.objects.create(
             transaction_type=Transaction.TransactionType.OUT,
@@ -127,7 +136,7 @@ class StockCardTest(TestCase):
             batch_lot='B01',
             quantity=Decimal('5'),
             reference_type=Transaction.ReferenceType.TRANSFER,
-            reference_id=99,
+            reference_id=transfer.id,
             user=self.user,
         )
         Transaction.objects.create(
@@ -137,7 +146,7 @@ class StockCardTest(TestCase):
             batch_lot='B01',
             quantity=Decimal('5'),
             reference_type=Transaction.ReferenceType.TRANSFER,
-            reference_id=99,
+            reference_id=transfer.id,
             user=self.user,
         )
         transfer_out.created_at = timezone.now() - timedelta(days=1)
@@ -161,6 +170,13 @@ class StockCardTest(TestCase):
 
     def test_stock_card_transfer_transactions_display_computed_fields(self):
         """Verify transfer transactions have computed display fields for UI rendering."""
+        destination = Location.objects.create(code='PKM2', name='Puskesmas Pembantu')
+        transfer = StockTransfer.objects.create(
+            source_location=self.location,
+            destination_location=destination,
+            created_by=self.user,
+        )
+
         # Create receiving transaction
         Transaction.objects.create(
             item=self.item,
@@ -179,18 +195,32 @@ class StockCardTest(TestCase):
             item=self.item,
             transaction_type=Transaction.TransactionType.OUT,
             reference_type=Transaction.ReferenceType.TRANSFER,
-            reference_id=99,
+            reference_id=transfer.id,
             quantity=Decimal('30'),
             location=self.location,
             sumber_dana=self.funding,
             user=self.user,
             batch_lot="BATCH-001",
         )
+        transfer_in = Transaction.objects.create(
+            item=self.item,
+            transaction_type=Transaction.TransactionType.IN,
+            reference_type=Transaction.ReferenceType.TRANSFER,
+            reference_id=transfer.id,
+            quantity=Decimal('30'),
+            location=destination,
+            sumber_dana=self.funding,
+            user=self.user,
+            batch_lot="BATCH-001",
+        )
         transfer_out.created_at = timezone.now() - timedelta(days=1)
         transfer_out.save(update_fields=['created_at'])
+        transfer_in.created_at = timezone.now() - timedelta(hours=12)
+        transfer_in.save(update_fields=['created_at'])
 
         response = self.client.get(
             reverse('stock:stock_card_detail', args=[self.item.id]),
+            {'sumber_dana': self.funding.id},
         )
 
         self.assertEqual(response.status_code, 200)
@@ -210,26 +240,70 @@ class StockCardTest(TestCase):
 
         # The transfer_out should be in the transactions (created last, so last in list)
         # Find it by reference_type
-        transfer_tx = None
+        transfer_out_tx = None
+        transfer_in_tx = None
         receiving_tx = None
         for tx in transactions:
-            if tx.reference_type == Transaction.ReferenceType.TRANSFER:
-                transfer_tx = tx
+            if (
+                tx.reference_type == Transaction.ReferenceType.TRANSFER
+                and tx.transaction_type == Transaction.TransactionType.OUT
+            ):
+                transfer_out_tx = tx
+            elif (
+                tx.reference_type == Transaction.ReferenceType.TRANSFER
+                and tx.transaction_type == Transaction.TransactionType.IN
+            ):
+                transfer_in_tx = tx
             elif tx.reference_type == Transaction.ReferenceType.RECEIVING:
                 receiving_tx = tx
         
-        self.assertIsNotNone(transfer_tx, "Transfer transaction not found in card")
+        self.assertIsNotNone(transfer_out_tx, "Transfer out transaction not found in card")
+        self.assertIsNotNone(transfer_in_tx, "Transfer in transaction not found in card")
         self.assertIsNotNone(receiving_tx, "Receiving transaction not found in card")
 
         # Verify transfer transaction has display fields
-        self.assertTrue(hasattr(transfer_tx, 'is_transfer_transaction'))
-        self.assertTrue(transfer_tx.is_transfer_transaction)
-        self.assertEqual(transfer_tx.transfer_quantity, Decimal('30'))
+        self.assertTrue(hasattr(transfer_out_tx, 'is_transfer_transaction'))
+        self.assertTrue(transfer_out_tx.is_transfer_transaction)
+        self.assertEqual(transfer_out_tx.transfer_quantity, Decimal('30'))
+        self.assertEqual(transfer_out_tx.activity_label, 'Mutasi Keluar')
+        self.assertEqual(transfer_out_tx.dari_kepada, 'Instalasi Farmasi')
+        self.assertEqual(transfer_out_tx.location_label, self.location.name)
+
+        self.assertTrue(transfer_in_tx.is_transfer_transaction)
+        self.assertEqual(transfer_in_tx.transfer_quantity, Decimal('30'))
+        self.assertEqual(transfer_in_tx.activity_label, 'Mutasi Masuk')
+        self.assertEqual(transfer_in_tx.dari_kepada, 'Instalasi Farmasi')
+        self.assertEqual(transfer_in_tx.location_label, destination.name)
 
         # Verify non-transfer transaction does not have transfer marker
         self.assertTrue(hasattr(receiving_tx, 'is_transfer_transaction'))
         self.assertFalse(receiving_tx.is_transfer_transaction)
         self.assertIsNone(receiving_tx.transfer_quantity)
+        self.assertEqual(receiving_tx.activity_label, 'Penerimaan')
+        self.assertEqual(receiving_tx.dari_kepada, 'Instalasi Farmasi')
+        self.assertEqual(receiving_tx.location_label, self.location.name)
+
+        self.assertContains(response, 'Aktivitas')
+        self.assertContains(response, 'Mutasi Masuk')
+        self.assertContains(response, 'Mutasi Keluar')
+        self.assertContains(response, 'Lokasi Stok')
+        self.assertContains(response, 'Harga Satuan: Rp 0')
+        self.assertContains(response, 'Instalasi Farmasi')
+        self.assertContains(response, 'Gudang Utama')
+        self.assertContains(response, 'Kolom <strong>Dari / Kepada</strong> menunjukkan fasilitas atau mitra dokumen', html=False)
+
+        print_response = self.client.get(
+            reverse('stock:stock_card_print', args=[self.item.id]),
+            {'sumber_dana': self.funding.id},
+        )
+        self.assertEqual(print_response.status_code, 200)
+        self.assertContains(print_response, 'Aktivitas')
+        self.assertContains(print_response, 'Mutasi Masuk')
+        self.assertContains(print_response, 'Mutasi Keluar')
+        self.assertContains(print_response, 'Lokasi')
+        self.assertContains(print_response, 'Harga Satuan: Rp 0')
+        self.assertContains(print_response, 'Instalasi Farmasi')
+        self.assertContains(print_response, 'Kolom Dari / Kepada menunjukkan fasilitas atau mitra dokumen.')
 
 
 class StockTransferModelTests(SimpleTestCase):

--- a/backend/apps/stock/views.py
+++ b/backend/apps/stock/views.py
@@ -154,6 +154,42 @@ def _parse_filter_date(value):
     return None
 
 
+def _get_stock_card_activity_label(tx):
+    if tx.reference_type == Transaction.ReferenceType.TRANSFER:
+        if tx.transaction_type == Transaction.TransactionType.IN:
+            return "Mutasi Masuk"
+        return "Mutasi Keluar"
+
+    activity_labels = {
+        Transaction.ReferenceType.RECEIVING: "Penerimaan",
+        Transaction.ReferenceType.DISTRIBUTION: "Distribusi",
+        Transaction.ReferenceType.RECALL: "Recall",
+        Transaction.ReferenceType.EXPIRED: "Kedaluwarsa",
+        Transaction.ReferenceType.ALLOCATION: "Alokasi",
+        Transaction.ReferenceType.ADJUSTMENT: "Penyesuaian",
+        Transaction.ReferenceType.INITIAL_IMPORT: "Import Awal",
+    }
+    return activity_labels.get(tx.reference_type, tx.get_reference_type_display())
+
+
+def _get_stock_card_counterparty_label(tx, *, facility_name, receiving_map, distribution_map, recall_map):
+    internal_reference_types = {
+        Transaction.ReferenceType.RECEIVING,
+        Transaction.ReferenceType.TRANSFER,
+        Transaction.ReferenceType.EXPIRED,
+        Transaction.ReferenceType.ALLOCATION,
+        Transaction.ReferenceType.ADJUSTMENT,
+        Transaction.ReferenceType.INITIAL_IMPORT,
+    }
+    if tx.reference_type in internal_reference_types:
+        return facility_name
+    if tx.reference_type == Transaction.ReferenceType.DISTRIBUTION:
+        return distribution_map.get(tx.reference_id, "")
+    if tx.reference_type == Transaction.ReferenceType.RECALL:
+        return recall_map.get(tx.reference_id, "")
+    return receiving_map.get(tx.reference_id, "")
+
+
 def _build_stock_card_data(item, location_id=None, sumber_dana_id=None,
                            date_from=None, date_to=None):
     """Build per-sumber-dana stock card data for a given item.
@@ -167,6 +203,7 @@ def _build_stock_card_data(item, location_id=None, sumber_dana_id=None,
     """
     from collections import OrderedDict
     from apps.receiving.models import ReceivingItem
+    from apps.core.models import SystemSettings
 
     queryset = (
         Transaction.objects.filter(item=item)
@@ -184,6 +221,7 @@ def _build_stock_card_data(item, location_id=None, sumber_dana_id=None,
         queryset = queryset.filter(created_at__date__lte=date_to)
 
     transactions = list(queryset)
+    facility_name = SystemSettings.get_settings().facility_name
 
     # ── Pre-fetch batch expiry dates for this item (avoids N+1) ───────
     batch_expiry_map = dict(
@@ -225,6 +263,7 @@ def _build_stock_card_data(item, location_id=None, sumber_dana_id=None,
     # ── Resolve supplier/facility names for DARI/KEPADA ──────────────
     receiving_supplier_map = {}
     distribution_facility_map = {}
+    recall_supplier_map = {}
 
     recv_ids = ref_id_sets.get(Transaction.ReferenceType.RECEIVING, set())
     if recv_ids:
@@ -247,6 +286,14 @@ def _build_stock_card_data(item, location_id=None, sumber_dana_id=None,
         ).only("id", "facility__name"):
             if d.facility:
                 distribution_facility_map[d.id] = d.facility.name
+
+    recall_ids = ref_id_sets.get(Transaction.ReferenceType.RECALL, set())
+    if recall_ids:
+        from apps.recall.models import Recall
+        for recall in Recall.objects.filter(id__in=recall_ids).select_related(
+            "supplier"
+        ).only("id", "supplier__name"):
+            recall_supplier_map[recall.id] = recall.supplier.name if recall.supplier else ""
 
     # ── Group by sumber_dana ─────────────────────────────────────────
     sd_groups = OrderedDict()
@@ -371,17 +418,14 @@ def _build_stock_card_data(item, location_id=None, sumber_dana_id=None,
                 tx.reference_id,
                 f"{tx.reference_type}-{tx.reference_id}",
             )
-            # DARI/KEPADA resolution
-            if tx.reference_type == Transaction.ReferenceType.RECEIVING:
-                tx.dari_kepada = receiving_supplier_map.get(
-                    tx.reference_id, ""
-                )
-            elif tx.reference_type == Transaction.ReferenceType.DISTRIBUTION:
-                tx.dari_kepada = distribution_facility_map.get(
-                    tx.reference_id, ""
-                )
-            else:
-                tx.dari_kepada = ""
+            tx.dari_kepada = _get_stock_card_counterparty_label(
+                tx,
+                facility_name=facility_name,
+                receiving_map=receiving_supplier_map,
+                distribution_map=distribution_facility_map,
+                recall_map=recall_supplier_map,
+            )
+            tx.location_label = tx.location.name if tx.location_id else ""
 
             # Expiry date from batch if available (pre-fetched)
             tx.expiry_display = ""
@@ -393,6 +437,7 @@ def _build_stock_card_data(item, location_id=None, sumber_dana_id=None,
             # Mark transfers for informational display
             tx.is_transfer_transaction = tx.reference_type == Transaction.ReferenceType.TRANSFER
             tx.transfer_quantity = tx.quantity if tx.is_transfer_transaction else None
+            tx.activity_label = _get_stock_card_activity_label(tx)
 
         # Determine Tahun Anggaran from earliest receiving year
         tahun_anggaran = timezone.now().year

--- a/backend/templates/stock/stock_card_detail.html
+++ b/backend/templates/stock/stock_card_detail.html
@@ -191,7 +191,7 @@
                     {% endif %}
                     <span class="badge bg-secondary-subtle text-secondary ms-2">{{ card.transactions|length }} transaksi</span>
                 </h6>
-                <div class="sd-price">Rp {{ card.unit_price|id_decimal:0 }}</div>
+                <div class="sd-price">Harga Satuan: Rp {{ card.unit_price|id_decimal:0 }}</div>
             </div>
 
             <div class="collapse show" id="sdCard{{ forloop.counter }}">
@@ -201,11 +201,14 @@
                             <tr>
                                 <th style="width: 80px;">Tgl</th>
                                 <th style="width: 115px;">Dokumen</th>
-                                <th>Dari / Kepada</th>
+                                <th style="width: 120px;">Aktivitas</th>
+                                <th style="width: 150px;">Dari / Kepada</th>
+                                <th style="width: 135px;">Lokasi Stok</th>
                                 <th style="width: 100px;">No Batch</th>
                                 <th style="width: 82px;">Exp Date</th>
                                 <th class="text-end" style="width: 75px;">Terima</th>
                                 <th class="text-end" style="width: 75px;">Keluar</th>
+                                <th class="text-end" style="width: 80px;">Mutasi</th>
                                 <th class="text-end" style="width: 85px;">Sisa</th>
                                 <th style="width: 80px;">Ketr</th>
                             </tr>
@@ -213,7 +216,8 @@
                         <tbody>
                             {% if card.opening_balance %}
                             <tr class="table-info">
-                                <td colspan="5" class="text-end fw-bold">SALDO AWAL</td>
+                                <td colspan="7" class="text-end fw-bold">SALDO AWAL</td>
+                                <td class="text-end">-</td>
                                 <td class="text-end">-</td>
                                 <td class="text-end">-</td>
                                 <td class="text-end fw-bold num-cell">{{ card.opening_balance|id_decimal:0 }}</td>
@@ -227,23 +231,30 @@
                                 <td>
                                     <code class="doc-ref">{{ tx.reference_label }}</code>
                                 </td>
+                                <td>
+                                    {% if tx.is_transfer_transaction %}
+                                        <span class="badge bg-info-subtle text-info-emphasis">{{ tx.activity_label }}</span>
+                                    {% else %}
+                                        <span class="badge bg-secondary-subtle text-secondary-emphasis">{{ tx.activity_label }}</span>
+                                    {% endif %}
+                                </td>
                                 <td>{{ tx.dari_kepada|default:"" }}</td>
+                                <td>{{ tx.location_label|default:"" }}</td>
                                 <td>{{ tx.batch_lot }}</td>
                                 <td class="text-center">{{ tx.expiry_display }}</td>
-                                <td class="text-end text-success fw-semibold num-cell">{% if tx.tx_in > 0 %}{{ tx.tx_in|id_decimal:0 }}{% endif %}</td>
+                                <td class="text-end text-success fw-semibold num-cell">{% if tx.tx_in > 0 and not tx.is_transfer_transaction %}{{ tx.tx_in|id_decimal:0 }}{% endif %}</td>
                                 <td class="text-end fw-semibold num-cell">
-                                    {% if tx.is_transfer_transaction %}
-                                        <span class="badge bg-info text-dark">Mutasi {{ tx.transfer_quantity|id_decimal:0 }}</span>
-                                    {% elif tx.tx_out > 0 %}
+                                    {% if tx.tx_out > 0 and not tx.is_transfer_transaction %}
                                         <span class="text-danger fw-semibold">{{ tx.tx_out|id_decimal:0 }}</span>
                                     {% endif %}
                                 </td>
+                                <td class="text-end text-info fw-semibold num-cell">{% if tx.is_transfer_transaction %}{{ tx.transfer_quantity|id_decimal:0 }}{% endif %}</td>
                                 <td class="text-end fw-bold bg-light num-cell">{{ tx.running_balance|id_decimal:0 }}</td>
                                 <td class="small">{{ tx.notes|truncatewords:8 }}</td>
                             </tr>
                             {% empty %}
                             <tr>
-                                <td colspan="9">
+                                <td colspan="12">
                                     <div class="text-center py-3 text-muted">
                                         <i class="bi bi-journal-x d-block fs-4 mb-1"></i>
                                         Tidak ada riwayat transaksi.
@@ -255,9 +266,10 @@
                         {% if card.transactions %}
                         <tfoot class="table-light fw-bold">
                             <tr>
-                                <td colspan="5" class="text-end">TOTAL</td>
+                                <td colspan="7" class="text-end">TOTAL</td>
                                 <td class="text-end text-success num-cell">{{ card.total_in|id_decimal:0 }}</td>
                                 <td class="text-end text-danger num-cell">{{ card.total_out|id_decimal:0 }}</td>
+                                <td class="text-end">-</td>
                                 <td class="text-end bg-light num-cell">{{ card.closing_balance|id_decimal:0 }}</td>
                                 <td></td>
                             </tr>
@@ -271,6 +283,9 @@
                     <span class="badge-stat"><strong>Saldo Akhir:</strong> {{ card.closing_balance|id_decimal:0 }}</span>
                     <span class="badge-stat"><strong>Total Masuk:</strong> <span class="text-success">{{ card.total_in|id_decimal:0 }}</span></span>
                     <span class="badge-stat"><strong>Total Keluar:</strong> <span class="text-danger">{{ card.total_out|id_decimal:0 }}</span></span>
+                </div>
+                <div class="px-3 py-2 border-top small text-muted bg-light">
+                    Kolom <strong>Dari / Kepada</strong> menunjukkan fasilitas atau mitra dokumen, sedangkan <strong>Lokasi Stok</strong> menunjukkan lokasi penyimpanan batch pada transaksi tersebut. Kolom <strong>Mutasi</strong> dipakai untuk perpindahan internal antar lokasi dan tetap memengaruhi <strong>Sisa</strong>, tetapi tidak dihitung ke <strong>Total Masuk</strong> atau <strong>Total Keluar</strong>.
                 </div>
             </div>
         </div>

--- a/backend/templates/stock/stock_card_print.html
+++ b/backend/templates/stock/stock_card_print.html
@@ -235,7 +235,7 @@
     <!-- ── Title + Unit Price ─────────────────────────────────────── -->
     <div class="card-title-row">
         <h2>Kartu Stok</h2>
-        <div class="card-unit-price">Rp {{ card.unit_price|id_decimal:0 }}</div>
+        <div class="card-unit-price">Harga Satuan: Rp {{ card.unit_price|id_decimal:0 }}</div>
     </div>
 
     <!-- ── Metadata ──────────────────────────────────────────────── -->
@@ -270,11 +270,14 @@
             <tr>
                 <th style="width: 68px;">Tgl</th>
                 <th style="width: 110px;">Dokumen</th>
-                <th>Dari / Kepada</th>
+                <th style="width: 90px;">Aktivitas</th>
+                <th style="width: 120px;">Dari / Kepada</th>
+                <th style="width: 90px;">Lokasi</th>
                 <th style="width: 90px;">No Batch</th>
                 <th style="width: 72px;">Exp Date</th>
                 <th style="width: 68px;">Terima</th>
                 <th style="width: 68px;">Keluar</th>
+                <th style="width: 68px;">Mutasi</th>
                 <th style="width: 78px;">Sisa</th>
                 <th style="width: 60px;">Ketr</th>
             </tr>
@@ -282,7 +285,8 @@
         <tbody>
             {% if card.opening_balance %}
             <tr class="opening-row">
-                <td colspan="5" style="text-align: right;">SALDO AWAL</td>
+                <td colspan="7" style="text-align: right;">SALDO AWAL</td>
+                <td class="num-cell">-</td>
                 <td class="num-cell">-</td>
                 <td class="num-cell">-</td>
                 <td class="num-cell">{{ card.opening_balance|id_decimal:0 }}</td>
@@ -294,38 +298,43 @@
             <tr>
                 <td class="text-center">{{ tx.created_at|date:"d/m/y" }}</td>
                 <td class="doc-cell">{{ tx.reference_label }}</td>
+                <td>{{ tx.activity_label }}</td>
                 <td>{{ tx.dari_kepada }}</td>
+                <td>{{ tx.location_label }}</td>
                 <td>{{ tx.batch_lot }}</td>
                 <td class="text-center">{{ tx.expiry_display }}</td>
-                <td class="num-cell">{% if tx.tx_in > 0 %}{{ tx.tx_in|id_decimal:0 }}{% endif %}</td>
+                <td class="num-cell">{% if tx.tx_in > 0 and not tx.is_transfer_transaction %}{{ tx.tx_in|id_decimal:0 }}{% endif %}</td>
                 <td class="num-cell">
-                    {% if tx.is_transfer_transaction %}
-                        Mutasi {{ tx.transfer_quantity|id_decimal:0 }}
-                    {% elif tx.tx_out > 0 %}
+                    {% if tx.tx_out > 0 and not tx.is_transfer_transaction %}
                         {{ tx.tx_out|id_decimal:0 }}
                     {% endif %}
                 </td>
+                <td class="num-cell">{% if tx.is_transfer_transaction %}{{ tx.transfer_quantity|id_decimal:0 }}{% endif %}</td>
                 <td class="num-cell">{{ tx.running_balance|id_decimal:0 }}</td>
                 <td>{{ tx.notes|truncatewords:6 }}</td>
             </tr>
             {% empty %}
             <tr class="empty-row">
-                <td colspan="9">Tidak ada riwayat transaksi.</td>
+                <td colspan="12">Tidak ada riwayat transaksi.</td>
             </tr>
             {% endfor %}
         </tbody>
         {% if card.transactions %}
         <tfoot>
             <tr class="tfoot-row">
-                <td colspan="5" style="text-align: right;">TOTAL</td>
+                <td colspan="7" style="text-align: right;">TOTAL</td>
                 <td class="num-cell">{{ card.total_in|id_decimal:0 }}</td>
                 <td class="num-cell">{{ card.total_out|id_decimal:0 }}</td>
+                <td class="num-cell">-</td>
                 <td class="num-cell">{{ card.closing_balance|id_decimal:0 }}</td>
                 <td></td>
             </tr>
         </tfoot>
         {% endif %}
     </table>
+    <div style="margin-top: 6px; font-size: 9px; color: #555;">
+        Kolom Dari / Kepada menunjukkan fasilitas atau mitra dokumen. Kolom Lokasi menunjukkan lokasi penyimpanan batch pada transaksi tersebut. Kolom Mutasi dipakai untuk perpindahan internal antar lokasi dan memengaruhi saldo berjalan, tetapi tidak masuk total penerimaan atau pengeluaran.
+    </div>
 </div>
 {% empty %}
 <div class="stock-card-page">
@@ -366,14 +375,14 @@
     <table class="ledger-table">
         <thead>
             <tr>
-                <th>Tgl</th><th>Dokumen</th><th>Dari / Kepada</th>
+                <th>Tgl</th><th>Dokumen</th><th>Aktivitas</th><th>Dari / Kepada</th><th>Lokasi</th>
                 <th>No Batch</th><th>Exp Date</th><th>Terima</th>
-                <th>Keluar</th><th>Sisa</th><th>Ketr</th>
+                <th>Keluar</th><th>Mutasi</th><th>Sisa</th><th>Ketr</th>
             </tr>
         </thead>
         <tbody>
             <tr class="empty-row">
-                <td colspan="9">Tidak ada riwayat transaksi.</td>
+                <td colspan="12">Tidak ada riwayat transaksi.</td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- clarify stock card transfer rows with explicit activity labels for inbound and outbound mutasi
- keep `Dari / Kepada` focused on facility or document counterparty and add a separate storage-location column
- keep unit price visible in the stock-card header while aligning detail and print views
- add regression coverage for the updated stock-card UI contract

## Problem
Issue #54 highlighted that stock-card transfer rows were hard to interpret because transfer semantics were mixed into the generic inbound/outbound layout, counterparties were unclear, and storage location context was missing.

## Solution
- enrich stock-card view data with activity labels and counterparty/location display fields
- update detail and print templates to distinguish transfer rows from regular stock movements
- add helper text so totals vs. transfer behavior are easier to understand
- keep the card header price visible without expanding the row layout

## Testing
- `DEBUG=True`
- `SECURE_SSL_REDIRECT=False`
- `./scripts/run-django-test.ps1 -Target apps.stock.tests`

## Related
- Closes #54
- Related follow-up: #55
