### PR TITLE
Fix dashboard module-scope authorization and data exposure

### DIFF
--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -27,10 +27,11 @@ from apps.core.views import (
 )
 from apps.core.versioning import DEFAULT_VERSION, SemanticVersion, read_version, write_version
 from apps.distribution.models import Distribution
-from apps.items.models import Facility, FundingSource
+from apps.items.models import Category, Facility, FundingSource, Item, Location, Unit
 from apps.lplpo.models import LPLPO
 from apps.puskesmas.models import PuskesmasRequest
 from apps.receiving.models import Receiving
+from apps.stock.models import Transaction
 from apps.users.models import ModuleAccess, User
 
 
@@ -165,6 +166,13 @@ class DashboardViewTests(TestCase):
             facility=cls.facility,
         )
 
+    def _set_scope(self, user, module, scope):
+        ModuleAccess.objects.update_or_create(
+            user=user,
+            module=module,
+            defaults={"scope": scope},
+        )
+
     def test_puskesmas_dashboard_uses_facility_scoped_template(self):
         own_lplpo = LPLPO.objects.create(
             facility=self.facility,
@@ -221,6 +229,97 @@ class DashboardViewTests(TestCase):
         self.assertIsNone(response.context["facility"])
         self.assertEqual(list(response.context["recent_lplpos"]), [])
         self.assertEqual(list(response.context["recent_requests"]), [])
+
+    def test_global_dashboard_requires_stock_view_scope(self):
+        user = User.objects.create_user(
+            username="dashboard-blocked",
+            password="TestPassword123!",
+            role=User.Role.ADMIN_UMUM,
+        )
+        self._set_scope(user, ModuleAccess.Module.STOCK, ModuleAccess.Scope.NONE)
+
+        self.client.force_login(user)
+        response = self.client.get(reverse("dashboard"))
+
+        self.assertEqual(response.status_code, 403)
+        self.assertContains(
+            response,
+            "Anda tidak memiliki izin untuk mengakses dashboard inventaris.",
+            status_code=403,
+        )
+
+    def test_global_dashboard_hides_transaction_user_without_users_scope(self):
+        viewer = User.objects.create_user(
+            username="dashboard-viewer",
+            password="TestPassword123!",
+            role=User.Role.ADMIN_UMUM,
+        )
+        actor = User.objects.create_user(
+            username="dashboard-actor",
+            password="TestPassword123!",
+            role=User.Role.GUDANG,
+        )
+        self._set_scope(viewer, ModuleAccess.Module.STOCK, ModuleAccess.Scope.VIEW)
+        self._set_scope(viewer, ModuleAccess.Module.USERS, ModuleAccess.Scope.NONE)
+        self._set_scope(viewer, ModuleAccess.Module.ADMIN_PANEL, ModuleAccess.Scope.NONE)
+
+        unit = Unit.objects.create(code="TAB", name="Tablet")
+        category = Category.objects.create(code="OBT", name="Obat")
+        funding_source = FundingSource.objects.create(code="DAK", name="Dana Alokasi Khusus")
+        location = Location.objects.create(code="GUD", name="Gudang Utama")
+        item = Item.objects.create(
+            nama_barang="Paracetamol 500mg",
+            satuan=unit,
+            kategori=category,
+        )
+        Transaction.objects.create(
+            transaction_type=Transaction.TransactionType.IN,
+            item=item,
+            location=location,
+            batch_lot="BATCH-001",
+            quantity="10",
+            unit_price="1000",
+            sumber_dana=funding_source,
+            reference_type=Transaction.ReferenceType.RECEIVING,
+            reference_id=1,
+            user=actor,
+        )
+
+        self.client.force_login(viewer)
+        response = self.client.get(reverse("dashboard"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "dashboard.html")
+        self.assertContains(response, "Paracetamol 500mg")
+        self.assertNotContains(response, "dashboard-actor")
+        self.assertNotContains(response, "Pengguna")
+
+    def test_global_dashboard_hides_unscoped_cards_and_actions(self):
+        viewer = User.objects.create_user(
+            username="dashboard-stock-only",
+            password="TestPassword123!",
+            role=User.Role.ADMIN_UMUM,
+        )
+        self._set_scope(viewer, ModuleAccess.Module.STOCK, ModuleAccess.Scope.VIEW)
+        self._set_scope(viewer, ModuleAccess.Module.ITEMS, ModuleAccess.Scope.NONE)
+        self._set_scope(viewer, ModuleAccess.Module.EXPIRED, ModuleAccess.Scope.NONE)
+        self._set_scope(viewer, ModuleAccess.Module.RECEIVING, ModuleAccess.Scope.NONE)
+        self._set_scope(viewer, ModuleAccess.Module.DISTRIBUTION, ModuleAccess.Scope.NONE)
+        self._set_scope(viewer, ModuleAccess.Module.USERS, ModuleAccess.Scope.NONE)
+        self._set_scope(viewer, ModuleAccess.Module.ADMIN_PANEL, ModuleAccess.Scope.NONE)
+
+        self.client.force_login(viewer)
+        response = self.client.get(reverse("dashboard"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Total Stok Aktif")
+        self.assertContains(response, 'href="/stock/transactions/"', html=False)
+        self.assertNotContains(response, "Total Jenis Barang")
+        self.assertNotContains(response, "Stok Rendah")
+        self.assertNotContains(response, 'href="/expired/alerts/?level=all&amp;pending=1"', html=False)
+        self.assertNotContains(response, "Buat Penerimaan")
+        self.assertNotContains(response, "Buat Permintaan Khusus")
+        self.assertNotContains(response, "Buat Mutasi Lokasi")
 
 
 class ErrorPageTemplateTests(TestCase):

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -76,6 +76,15 @@ def _render_error_page(request, template_name, response_status, **context):
     return render(request, template_name, context, status=response_status)
 
 
+def _can_access_global_dashboard(user):
+    if not getattr(user, "is_authenticated", False):
+        return False
+
+    return user.is_superuser or has_module_scope(
+        user, ModuleAccess.Module.STOCK, ModuleAccess.Scope.VIEW
+    )
+
+
 def maintenance_mode(request):
     _log_error_event(app_logger, "warning", "service_unavailable", request, 503)
     context = _build_error_context(
@@ -204,6 +213,31 @@ def dashboard(request):
             },
         )
 
+    if not _can_access_global_dashboard(request.user):
+        raise PermissionDenied(
+            "Anda tidak memiliki izin untuk mengakses dashboard inventaris."
+        )
+
+    can_view_items = has_module_scope(
+        request.user, ModuleAccess.Module.ITEMS, ModuleAccess.Scope.VIEW
+    )
+    can_view_expired = has_module_scope(
+        request.user, ModuleAccess.Module.EXPIRED, ModuleAccess.Scope.VIEW
+    )
+    can_create_receiving = has_module_scope(
+        request.user, ModuleAccess.Module.RECEIVING, ModuleAccess.Scope.OPERATE
+    )
+    can_create_distribution = has_module_scope(
+        request.user, ModuleAccess.Module.DISTRIBUTION, ModuleAccess.Scope.OPERATE
+    )
+    can_create_transfer = has_module_scope(
+        request.user, ModuleAccess.Module.STOCK, ModuleAccess.Scope.OPERATE
+    )
+    can_view_transaction_user = _can_access_administration_history(request.user)
+    has_quick_actions = any(
+        [can_create_receiving, can_create_distribution, can_create_transfer]
+    )
+
     today = timezone.now().date()
     three_months_later = today + timedelta(days=90)
     thirty_days_ago = today - timedelta(days=29)
@@ -224,28 +258,33 @@ def dashboard(request):
     )
 
     # Stats
-    total_items = Item.objects.filter(is_active=True).count()
+    total_items = Item.objects.filter(is_active=True).count() if can_view_items else None
     total_stock_entries = stock_totals["total_stock_entries"]
     total_stock_quantity = stock_totals["total_stock_quantity"]
     total_stock_value = stock_totals["total_stock_value"]
 
     # Low stock: items where total stock quantity is below minimum_stock
-    low_stock_items = (
-        Item.objects.filter(is_active=True)
-        .annotate(total_qty=Sum("stock_entries__quantity"))
-        .filter(
-            Q(total_qty__lt=F("minimum_stock")) | Q(total_qty__isnull=True),
-            minimum_stock__gt=0,
+    low_stock_count = None
+    if can_view_items:
+        low_stock_items = (
+            Item.objects.filter(is_active=True)
+            .annotate(total_qty=Sum("stock_entries__quantity"))
+            .filter(
+                Q(total_qty__lt=F("minimum_stock")) | Q(total_qty__isnull=True),
+                minimum_stock__gt=0,
+            )
         )
-    )
-    low_stock_count = low_stock_items.count()
+        low_stock_count = low_stock_items.count()
 
     # Expiring soon: stock entries expiring within 3 months
-    expiring_soon_queryset = stock_queryset.filter(expiry_date__lte=three_months_later)
-    expiring_soon = expiring_soon_queryset.select_related("item").order_by(
-        "expiry_date"
-    )[:10]
-    expiring_soon_count = expiring_soon_queryset.count()
+    expiring_soon = []
+    expiring_soon_count = None
+    if can_view_expired:
+        expiring_soon_queryset = stock_queryset.filter(expiry_date__lte=three_months_later)
+        expiring_soon = expiring_soon_queryset.select_related("item").order_by(
+            "expiry_date"
+        )[:10]
+        expiring_soon_count = expiring_soon_queryset.count()
 
     today_tx_filter = Q(created_at__date=today)
     tx_last_30_days = Transaction.objects.filter(created_at__date__gte=thirty_days_ago)
@@ -278,9 +317,12 @@ def dashboard(request):
         outbound_percent_30_days = 0
 
     # Recent transactions
-    recent_transactions = Transaction.objects.select_related("item", "user").order_by(
-        "-created_at"
-    )[:10]
+    recent_transactions_queryset = Transaction.objects.select_related("item")
+    if can_view_transaction_user:
+        recent_transactions_queryset = recent_transactions_queryset.select_related(
+            "user"
+        )
+    recent_transactions = recent_transactions_queryset.order_by("-created_at")[:10]
 
     return render(
         request,
@@ -293,6 +335,12 @@ def dashboard(request):
             "low_stock_count": low_stock_count,
             "expiring_soon_count": expiring_soon_count,
             "expiring_soon": expiring_soon,
+            "show_items_metrics": can_view_items,
+            "show_expiring_metrics": can_view_expired,
+            "show_receiving_quick_action": can_create_receiving,
+            "show_distribution_quick_action": can_create_distribution,
+            "show_transfer_quick_action": can_create_transfer,
+            "has_quick_actions": has_quick_actions,
             "today_transaction_count": today_transaction_count,
             "inbound_30_days": inbound_30_days,
             "outbound_30_days": outbound_30_days,
@@ -300,6 +348,7 @@ def dashboard(request):
             "outbound_percent_30_days": outbound_percent_30_days,
             "thirty_days_ago": thirty_days_ago,
             "today": today,
+            "show_transaction_user": can_view_transaction_user,
             "recent_transactions": recent_transactions,
         },
     )

--- a/backend/templates/dashboard.html
+++ b/backend/templates/dashboard.html
@@ -7,6 +7,7 @@
 {% block content %}
 <!-- Stats Row -->
 <div class="row g-3 mb-4">
+    {% if show_items_metrics %}
     <div class="col-sm-6 col-xl-3">
         <div class="card stat-card">
             <div class="card-body">
@@ -22,6 +23,7 @@
             </div>
         </div>
     </div>
+    {% endif %}
     <div class="col-sm-6 col-xl-3">
         <div class="card stat-card">
             <div class="card-body">
@@ -37,6 +39,7 @@
             </div>
         </div>
     </div>
+    {% if show_items_metrics %}
     <div class="col-sm-6 col-xl-3">
         <div class="card stat-card">
             <div class="card-body">
@@ -52,6 +55,8 @@
             </div>
         </div>
     </div>
+    {% endif %}
+    {% if show_expiring_metrics %}
     <div class="col-sm-6 col-xl-3">
         <div class="card stat-card">
             <div class="card-body">
@@ -68,6 +73,7 @@
             </div>
         </div>
     </div>
+    {% endif %}
 </div>
 
 <!-- Secondary KPIs -->
@@ -131,7 +137,7 @@
 </div>
 
 <div class="row g-3 mb-4">
-    <div class="col-lg-8">
+    <div class="{% if has_quick_actions %}col-lg-8{% else %}col-lg-12{% endif %}">
         <div class="card content-card h-100">
             <div class="card-header">
                 <span><i class="bi bi-arrow-left-right me-2"></i>Pergerakan Stok (30 Hari Terakhir)</span>
@@ -165,32 +171,40 @@
             </div>
         </div>
     </div>
+    {% if has_quick_actions %}
     <div class="col-lg-4">
         <div class="card content-card h-100">
             <div class="card-header">
                 <span><i class="bi bi-lightning-charge me-2"></i>Aksi Cepat</span>
             </div>
             <div class="card-body d-grid gap-2">
+                {% if show_receiving_quick_action %}
                 <a href="{% url 'receiving:receiving_create' %}" class="btn btn-primary">
                     <i class="bi bi-plus-circle me-1"></i>Buat Penerimaan
                 </a>
+                {% endif %}
+                {% if show_distribution_quick_action %}
                 <a href="{% url 'distribution:special_request_create' %}" class="btn btn-outline-secondary">
                     <i class="bi bi-send-plus me-1"></i>Buat Permintaan Khusus
                 </a>
+                {% endif %}
+                {% if show_transfer_quick_action %}
                 <a href="{% url 'stock:transfer_create' %}" class="btn btn-outline-secondary">
                     <i class="bi bi-arrow-left-right me-1"></i>Buat Mutasi Lokasi
                 </a>
+                {% endif %}
                 <a href="{% url 'stock:transaction_list' %}" class="btn btn-outline-secondary">
                     <i class="bi bi-clock-history me-1"></i>Lihat Transaksi
                 </a>
             </div>
         </div>
     </div>
+    {% endif %}
 </div>
 
 <div class="row g-3">
     <!-- Recent Transactions -->
-    <div class="col-lg-8">
+    <div class="{% if show_expiring_metrics %}col-lg-8{% else %}col-lg-12{% endif %}">
         <div class="card content-card">
             <div class="card-header">
                 <span><i class="bi bi-clock-history me-2"></i>Transaksi Terakhir</span>
@@ -206,7 +220,9 @@
                                 <th>Tipe</th>
                                 <th>Barang</th>
                                 <th>Kuantitas</th>
+                                {% if show_transaction_user %}
                                 <th>Pengguna</th>
+                                {% endif %}
                             </tr>
                         </thead>
                         <tbody>
@@ -226,7 +242,9 @@
                                 </td>
                                 <td>{{ tx.item.nama_barang|truncatechars:40 }}</td>
                                 <td>{{ tx.quantity }}</td>
+                                {% if show_transaction_user %}
                                 <td>{{ tx.user }}</td>
+                                {% endif %}
                             </tr>
                             {% endfor %}
                         </tbody>
@@ -243,6 +261,7 @@
     </div>
 
     <!-- Item Mendekati Kedaluwarsa -->
+    {% if show_expiring_metrics %}
     <div class="col-lg-4">
         <div class="card content-card">
             <div class="card-header">
@@ -273,5 +292,6 @@
             </div>
         </div>
     </div>
+    {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Closes #53

## Summary
- require stock-view access before rendering the global dashboard for non-Puskesmas users
- hide recent transaction user identities unless the viewer already has user/admin visibility
- make dashboard cards and quick actions module-scope aware so users only see modules they can access
- add regression coverage for denied access, user masking, and stock-only dashboard rendering

## Validation
- .\\scripts\\run-django-test.ps1 -Target apps.core.tests.test_core.DashboardViewTests
- .\\scripts\\run-django-test.ps1 -Target apps.core.tests