### PR TITLE
Fix dashboard transaction helper text semantics

### DIFF
--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -334,6 +334,52 @@ class DashboardViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["total_stock_quantity"], Decimal("40"))
 
+    def test_global_dashboard_today_transaction_count_includes_return_transactions(self):
+        viewer = User.objects.create_user(
+            username="dashboard-transaction-count",
+            password="TestPassword123!",
+            role=User.Role.ADMIN_UMUM,
+        )
+        actor = User.objects.create_user(
+            username="dashboard-return-actor",
+            password="TestPassword123!",
+            role=User.Role.GUDANG,
+        )
+        self._set_scope(viewer, ModuleAccess.Module.STOCK, ModuleAccess.Scope.VIEW)
+        self._set_scope(viewer, ModuleAccess.Module.EXPIRED, ModuleAccess.Scope.NONE)
+        self._set_scope(viewer, ModuleAccess.Module.ITEMS, ModuleAccess.Scope.NONE)
+        self._set_scope(viewer, ModuleAccess.Module.USERS, ModuleAccess.Scope.NONE)
+        self._set_scope(viewer, ModuleAccess.Module.ADMIN_PANEL, ModuleAccess.Scope.NONE)
+
+        unit = Unit.objects.create(code="RET", name="Retur")
+        category = Category.objects.create(code="RET", name="Retur Test")
+        funding_source = FundingSource.objects.create(code="RET", name="Retur Funding")
+        location = Location.objects.create(code="GDRET", name="Gudang Retur")
+        item = Item.objects.create(
+            nama_barang="Item Retur Dashboard",
+            satuan=unit,
+            kategori=category,
+        )
+        Transaction.objects.create(
+            transaction_type=Transaction.TransactionType.RETURN,
+            item=item,
+            location=location,
+            batch_lot="RETURN-001",
+            quantity=Decimal("5"),
+            unit_price=Decimal("1000"),
+            sumber_dana=funding_source,
+            reference_type=Transaction.ReferenceType.RECALL,
+            reference_id=1,
+            user=actor,
+        )
+
+        self.client.force_login(viewer)
+        response = self.client.get(reverse("dashboard"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["today_transaction_count"], 1)
+        self.assertContains(response, "Semua jenis transaksi")
+
     def test_global_dashboard_expiring_soon_excludes_already_expired_batches(self):
         viewer = User.objects.create_user(
             username="dashboard-expiring-soon",

--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -360,7 +360,8 @@ class DashboardViewTests(TestCase):
             satuan=unit,
             kategori=category,
         )
-        Transaction.objects.create(
+        fixed_now = timezone.now().replace(hour=12, minute=0, second=0, microsecond=0)
+        today_transaction = Transaction.objects.create(
             transaction_type=Transaction.TransactionType.RETURN,
             item=item,
             location=location,
@@ -371,6 +372,22 @@ class DashboardViewTests(TestCase):
             reference_type=Transaction.ReferenceType.RECALL,
             reference_id=1,
             user=actor,
+        )
+        tomorrow_transaction = Transaction.objects.create(
+            transaction_type=Transaction.TransactionType.RETURN,
+            item=item,
+            location=location,
+            batch_lot="RETURN-002",
+            quantity=Decimal("3"),
+            unit_price=Decimal("1000"),
+            sumber_dana=funding_source,
+            reference_type=Transaction.ReferenceType.RECALL,
+            reference_id=2,
+            user=actor,
+        )
+        Transaction.objects.filter(pk=today_transaction.pk).update(created_at=fixed_now)
+        Transaction.objects.filter(pk=tomorrow_transaction.pk).update(
+            created_at=fixed_now + timedelta(days=1)
         )
 
         self.client.force_login(viewer)

--- a/backend/templates/dashboard.html
+++ b/backend/templates/dashboard.html
@@ -129,7 +129,7 @@
                 </div>
                 <div class="stat-value mb-2">{{ today_transaction_count }}</div>
                 <div class="d-flex justify-content-between text-muted small">
-                    <span>Masuk + Keluar + Penyesuaian</span>
+                    <span>Semua jenis transaksi</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- align the "Transaksi Hari Ini" helper text with the existing all-types transaction count
- add a regression test proving RETURN transactions are counted in the dashboard KPI

## Testing
- ./scripts/run-django-test.ps1 -Target apps.core.tests.test_core.DashboardViewTests.test_global_dashboard_today_transaction_count_includes_return_transactions
- ./scripts/run-django-test.ps1 -Target apps.core.tests.test_core.DashboardViewTests.test_global_dashboard_total_stock_quantity_uses_available_stock

Closes #51