### PR TITLE
Fix stock opname medium-severity workflow gaps

### DIFF
--- a/SYSTEM_MODEL.md
+++ b/SYSTEM_MODEL.md
@@ -335,7 +335,7 @@ Operational mutation points (from app behavior and admin import logic):
 - Recall verify decreases stock and posts `Transaction(OUT, reference_type=RECALL)`
 - Expired verify decreases stock and posts `Transaction(OUT, reference_type=EXPIRED)`
 - Stock transfer complete posts paired `OUT` and `IN` transfer transactions and adjusts source/destination stock
-- Stock opname completion may post adjustment transactions based on discrepancy handling
+- Stock opname completion currently records workflow completion only (`status=COMPLETED`, `completed_at`) and does not mutate `Stock` or write `Transaction` rows
 - Allocation:
   - Approval phase auto-generates `Distribution(type=ALLOCATION, status=VERIFIED)` per facility — no stock mutation at this point
   - Per-distribution delivery confirmation decreases `Stock.quantity` and posts `Transaction(OUT, reference_type=ALLOCATION, reference_id=allocation.pk)`

--- a/backend/apps/stock_opname/tests.py
+++ b/backend/apps/stock_opname/tests.py
@@ -216,11 +216,23 @@ class StockOpnameInputValidationTests(StockOpnameTestMixin, TestCase):
 
     def test_location_filter_is_preserved_after_post(self):
         self.client.force_login(self.gudang)
+        input_url = reverse("stock_opname:opname_input", args=[self.opname.pk])
+
+        get_response = self.client.get(
+            f"{input_url}?location={self.location.pk}",
+            secure=True,
+        )
+
+        self.assertEqual(get_response.status_code, 200)
+        self.assertContains(
+            get_response,
+            f'<input type="hidden" name="location" value="{self.location.pk}">',
+            html=True,
+        )
 
         response = self.client.post(
-            reverse("stock_opname:opname_input", args=[self.opname.pk]),
+            f"{input_url}?location={self.location.pk}",
             {
-                "location": str(self.location.pk),
                 f"qty_{self.opname_item.pk}": "90",
                 f"notes_{self.opname_item.pk}": "Rak depan",
             },
@@ -230,7 +242,7 @@ class StockOpnameInputValidationTests(StockOpnameTestMixin, TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
             response.headers["Location"],
-            f"{reverse('stock_opname:opname_input', args=[self.opname.pk])}?location={self.location.pk}",
+            f"{input_url}?location={self.location.pk}",
         )
 
 

--- a/backend/apps/stock_opname/tests.py
+++ b/backend/apps/stock_opname/tests.py
@@ -214,6 +214,25 @@ class StockOpnameInputValidationTests(StockOpnameTestMixin, TestCase):
         self.assertEqual(self.opname_item.actual_quantity, Decimal("95.50"))
         self.assertEqual(self.opname_item.notes, "Disesuaikan")
 
+    def test_location_filter_is_preserved_after_post(self):
+        self.client.force_login(self.gudang)
+
+        response = self.client.post(
+            reverse("stock_opname:opname_input", args=[self.opname.pk]),
+            {
+                "location": str(self.location.pk),
+                f"qty_{self.opname_item.pk}": "90",
+                f"notes_{self.opname_item.pk}": "Rak depan",
+            },
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.headers["Location"],
+            f"{reverse('stock_opname:opname_input', args=[self.opname.pk])}?location={self.location.pk}",
+        )
+
 
 class StockOpnameApprovalAccessTest(StockOpnameTestMixin, TestCase):
     def setUp(self):

--- a/backend/templates/stock_opname/opname_input.html
+++ b/backend/templates/stock_opname/opname_input.html
@@ -28,6 +28,7 @@
 
                 <form method="post">
                     {% csrf_token %}
+                    <input type="hidden" name="location" value="{{ selected_location }}">
                     <div class="table-responsive">
                         <table class="table table-sm table-hover align-middle">
                             <thead>

--- a/docs/code-wiki/app-map.md
+++ b/docs/code-wiki/app-map.md
@@ -94,7 +94,7 @@ This page answers "where should I look?" for each module.
 
 ## `stock_opname`
 
-- Purpose: physical stock counting and discrepancy completion
+- Purpose: physical stock counting and discrepancy reporting
 - Start with:
   - `backend/apps/stock_opname/models.py`
   - `backend/apps/stock_opname/views.py`

--- a/docs/code-wiki/workflows-and-stock.md
+++ b/docs/code-wiki/workflows-and-stock.md
@@ -77,7 +77,9 @@ Do not treat model save events as the main inventory mutation mechanism. Stock c
 - Files:
   - `backend/apps/stock_opname/views.py`
 - Mutation rule:
-  - Completion may create adjustment transactions based on counted discrepancies
+  - Start snapshots current `Stock.quantity` into `StockOpnameItem.system_quantity`
+  - Completion marks the session as finished and timestamps it
+  - Completion does not currently mutate `Stock` or write `Transaction` rows; discrepancy handling remains a reporting/follow-up step
 
 ## Document Numbering
 


### PR DESCRIPTION
## Summary
- preserve the selected location filter through the stock opname input POST/redirect flow
- add a regression test covering the preserved location query parameter
- align stock opname workflow documentation with the current implementation, clarifying that completion does not mutate stock or write transactions

## Testing
- `python manage.py test apps.stock_opname`

## Notes
- References issue #67 for the medium-severity findings.