### PR TITLE
[codex] Harden privileged user management paths

### DIFF
--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -844,3 +844,61 @@ class ProtectedUserManagementGuardsTest(TestCase):
                 for message in messages
             )
         )
+
+    def test_bulk_activate_skips_admin_accounts_for_non_superuser_manager(self):
+        self.super_admin.is_active = False
+        self.super_admin.save(update_fields=["is_active"])
+        self.standard_user.is_active = False
+        self.standard_user.save(update_fields=["is_active"])
+
+        response = self.client.post(
+            reverse("users:user_bulk_action"),
+            {
+                "action": "activate",
+                "selected_users": [self.super_admin.pk, self.standard_user.pk],
+            },
+            secure=True,
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.super_admin.refresh_from_db()
+        self.standard_user.refresh_from_db()
+        self.assertFalse(self.super_admin.is_active)
+        self.assertTrue(self.standard_user.is_active)
+        messages = [message.message for message in get_messages(response.wsgi_request)]
+        self.assertTrue(
+            any(
+                "1 akun admin dilewati karena hanya dapat dikelola oleh superuser."
+                in message
+                for message in messages
+            )
+        )
+
+    def test_bulk_delete_skips_admin_accounts_for_non_superuser_manager(self):
+        self.super_admin.is_active = False
+        self.super_admin.save(update_fields=["is_active"])
+        self.standard_user.is_active = False
+        self.standard_user.save(update_fields=["is_active"])
+
+        response = self.client.post(
+            reverse("users:user_bulk_action"),
+            {
+                "action": "delete",
+                "selected_users": [self.super_admin.pk, self.standard_user.pk],
+            },
+            secure=True,
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(User.objects.filter(pk=self.super_admin.pk).exists())
+        self.assertFalse(User.objects.filter(pk=self.standard_user.pk).exists())
+        messages = [message.message for message in get_messages(response.wsgi_request)]
+        self.assertTrue(
+            any(
+                "1 akun admin dilewati karena hanya dapat dikelola oleh superuser."
+                in message
+                for message in messages
+            )
+        )

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -722,3 +722,125 @@ class UACRoleMatrixTest(TestCase):
             ModuleAccess.Scope.APPROVE,
         )
         self.assertTrue(has_module_permission(user, "puskesmas.view_puskesmasrequest"))
+
+
+class ProtectedUserManagementGuardsTest(TestCase):
+    def setUp(self):
+        self.super_admin = User.objects.create_superuser(
+            username="super_admin",
+            email="super_admin@example.com",
+            password="VeryStrongPass123!",
+        )
+        self.manager_user = User.objects.create_user(
+            username="user_manager",
+            email="user_manager@example.com",
+            password="VeryStrongPass123!",
+            role=User.Role.GUDANG,
+        )
+        ModuleAccess.objects.update_or_create(
+            user=self.manager_user,
+            module=ModuleAccess.Module.USERS,
+            defaults={"scope": ModuleAccess.Scope.MANAGE},
+        )
+        self.standard_user = User.objects.create_user(
+            username="standard_user",
+            email="standard_user@example.com",
+            password="VeryStrongPass123!",
+            role=User.Role.AUDITOR,
+        )
+        self.client.force_login(self.manager_user)
+
+    def test_non_superuser_cannot_open_admin_edit_form(self):
+        response = self.client.get(
+            reverse("users:user_update", args=[self.super_admin.pk]),
+            secure=True,
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(
+            response,
+            "https://testserver" + reverse("users:user_list"),
+            status_code=302,
+            target_status_code=200,
+        )
+        self.assertIn(
+            "Akun admin hanya dapat dikelola oleh superuser.",
+            [message.message for message in get_messages(response.wsgi_request)],
+        )
+
+    def test_non_superuser_cannot_reset_admin_password(self):
+        response = self.client.post(
+            reverse("users:user_reset_password", args=[self.super_admin.pk]),
+            {
+                "password1": "ResetBlocked123!",
+                "password2": "ResetBlocked123!",
+            },
+            secure=True,
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.super_admin.refresh_from_db()
+        self.assertTrue(self.super_admin.check_password("VeryStrongPass123!"))
+        self.assertIn(
+            "Akun admin hanya dapat dikelola oleh superuser.",
+            [message.message for message in get_messages(response.wsgi_request)],
+        )
+
+    def test_non_superuser_cannot_toggle_admin_active_status_via_ajax(self):
+        response = self.client.post(
+            reverse("users:user_toggle_active", args=[self.super_admin.pk]),
+            secure=True,
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.super_admin.refresh_from_db()
+        self.assertTrue(self.super_admin.is_active)
+        self.assertEqual(
+            response.json(),
+            {
+                "success": False,
+                "error": "Akun admin hanya dapat dikelola oleh superuser.",
+            },
+        )
+
+    def test_non_superuser_cannot_delete_admin_account(self):
+        response = self.client.post(
+            reverse("users:user_delete", args=[self.super_admin.pk]),
+            secure=True,
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(User.objects.filter(pk=self.super_admin.pk).exists())
+        self.assertIn(
+            "Akun admin hanya dapat dikelola oleh superuser.",
+            [message.message for message in get_messages(response.wsgi_request)],
+        )
+
+    def test_bulk_action_skips_admin_accounts_for_non_superuser_manager(self):
+        response = self.client.post(
+            reverse("users:user_bulk_action"),
+            {
+                "action": "deactivate",
+                "selected_users": [self.super_admin.pk, self.standard_user.pk],
+            },
+            secure=True,
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.super_admin.refresh_from_db()
+        self.standard_user.refresh_from_db()
+        self.assertTrue(self.super_admin.is_active)
+        self.assertFalse(self.standard_user.is_active)
+        messages = [message.message for message in get_messages(response.wsgi_request)]
+        self.assertTrue(
+            any(
+                "1 akun admin dilewati karena hanya dapat dikelola oleh superuser."
+                in message
+                for message in messages
+            )
+        )

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.db.models import ProtectedError
+from django.db.models import Q
 from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 
@@ -31,9 +32,29 @@ def _can_manage_users(user):
     return has_module_scope(user, ModuleAccess.Module.USERS, ModuleAccess.Scope.MANAGE)
 
 
+def _is_protected_user_account(user_obj):
+    return user_obj.is_superuser or user_obj.role == User.Role.ADMIN
+
+
 def _forbidden_manage_user(request, message):
     messages.error(request, message)
     return redirect("dashboard")
+
+
+def _forbidden_protected_user_mutation(request, is_ajax=False):
+    message = "Akun admin hanya dapat dikelola oleh superuser."
+    if is_ajax:
+        return JsonResponse({"success": False, "error": message}, status=403)
+    messages.error(request, message)
+    return redirect("users:user_list")
+
+
+def _ensure_can_mutate_target_user(request, target_user, is_ajax=False):
+    if request.user.is_superuser:
+        return None
+    if _is_protected_user_account(target_user):
+        return _forbidden_protected_user_mutation(request, is_ajax=is_ajax)
+    return None
 
 
 def _effective_scope_rows(user_obj):
@@ -182,6 +203,9 @@ def user_update(request, pk):
         )
 
     target_user = get_object_or_404(User, pk=pk)
+    protected_response = _ensure_can_mutate_target_user(request, target_user)
+    if protected_response:
+        return protected_response
 
     if request.method == "POST":
         form = UserUpdateForm(request.POST, instance=target_user)
@@ -218,6 +242,11 @@ def user_toggle_active(request, pk):
         )
 
     target_user = get_object_or_404(User, pk=pk)
+    protected_response = _ensure_can_mutate_target_user(
+        request, target_user, is_ajax=is_ajax
+    )
+    if protected_response:
+        return protected_response
     if request.method != "POST":
         if is_ajax:
             return JsonResponse({"success": False, "error": "Metode tidak diizinkan."}, status=405)
@@ -258,6 +287,9 @@ def user_delete(request, pk):
         )
 
     target_user = get_object_or_404(User, pk=pk)
+    protected_response = _ensure_can_mutate_target_user(request, target_user)
+    if protected_response:
+        return protected_response
     if request.method != "POST":
         return redirect("users:user_list")
 
@@ -329,41 +361,73 @@ def user_bulk_action(request):
         return redirect("users:user_list")
 
     queryset = User.objects.filter(pk__in=pks)
+    protected_accounts = queryset.filter(
+        Q(is_superuser=True) | Q(role=User.Role.ADMIN)
+    )
+    protected_count = 0
+    if not request.user.is_superuser:
+        protected_count = protected_accounts.count()
+        queryset = queryset.exclude(pk__in=protected_accounts.values("pk"))
     count = queryset.count()
 
     if action == "activate":
         queryset.update(is_active=True)
-        messages.success(request, f"{count} pengguna berhasil diaktifkan.")
+        message = f"{count} pengguna berhasil diaktifkan."
+        if protected_count:
+            message = (
+                f"{message} {protected_count} akun admin dilewati karena hanya "
+                "dapat dikelola oleh superuser."
+            )
+            messages.warning(request, message)
+        else:
+            messages.success(request, message)
     elif action == "deactivate":
         updated = queryset.exclude(pk=request.user.pk).update(is_active=False)
         if updated < count:
-            messages.warning(
-                request,
+            message = (
                 f"{updated} dari {count} pengguna dinonaktifkan. "
-                f"Akun Anda sendiri tidak dapat dinonaktifkan.",
+                f"Akun Anda sendiri tidak dapat dinonaktifkan."
             )
+            if protected_count:
+                message = (
+                    f"{message} {protected_count} akun admin dilewati karena "
+                    "hanya dapat dikelola oleh superuser."
+                )
+            messages.warning(request, message)
         else:
-            messages.success(request, f"{updated} pengguna berhasil dinonaktifkan.")
+            message = f"{updated} pengguna berhasil dinonaktifkan."
+            if protected_count:
+                message = (
+                    f"{message} {protected_count} akun admin dilewati karena "
+                    "hanya dapat dikelola oleh superuser."
+                )
+                messages.warning(request, message)
+            else:
+                messages.success(request, message)
     elif action == "delete":
         inactive = queryset.filter(is_active=False)
         active_count = queryset.filter(is_active=True).count()
         deleted_count = 0
-        protected_count = 0
+        related_protected_count = 0
         for user_obj in inactive:
             try:
                 user_obj.delete()
                 deleted_count += 1
             except ProtectedError:
-                protected_count += 1
-        if active_count or protected_count:
+                related_protected_count += 1
+        if active_count or related_protected_count or protected_count:
             message_parts = [f"{deleted_count} pengguna dihapus."]
             if active_count:
                 message_parts.append(
                     f"{active_count} pengguna aktif tidak dapat dihapus."
                 )
+            if related_protected_count:
+                message_parts.append(
+                    f"{related_protected_count} pengguna memiliki data terkait dan tidak dapat dihapus."
+                )
             if protected_count:
                 message_parts.append(
-                    f"{protected_count} pengguna memiliki data terkait dan tidak dapat dihapus."
+                    f"{protected_count} akun admin dilewati karena hanya dapat dikelola oleh superuser."
                 )
             messages.warning(
                 request,
@@ -388,6 +452,9 @@ def user_reset_password(request, pk):
         )
 
     target_user = get_object_or_404(User, pk=pk)
+    protected_response = _ensure_can_mutate_target_user(request, target_user)
+    if protected_response:
+        return protected_response
     if request.method != "POST":
         return redirect("users:user_list")
 

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -32,8 +32,12 @@ def _can_manage_users(user):
     return has_module_scope(user, ModuleAccess.Module.USERS, ModuleAccess.Scope.MANAGE)
 
 
+def _protected_user_account_q():
+    return Q(is_superuser=True) | Q(role=User.Role.ADMIN)
+
+
 def _is_protected_user_account(user_obj):
-    return user_obj.is_superuser or user_obj.role == User.Role.ADMIN
+    return User.objects.filter(pk=user_obj.pk).filter(_protected_user_account_q()).exists()
 
 
 def _forbidden_manage_user(request, message):
@@ -361,9 +365,7 @@ def user_bulk_action(request):
         return redirect("users:user_list")
 
     queryset = User.objects.filter(pk__in=pks)
-    protected_accounts = queryset.filter(
-        Q(is_superuser=True) | Q(role=User.Role.ADMIN)
-    )
+    protected_accounts = queryset.filter(_protected_user_account_q())
     protected_count = 0
     if not request.user.is_superuser:
         protected_count = protected_accounts.count()


### PR DESCRIPTION
## Summary
- block non-superusers from editing or mutating privileged admin accounts in dashboard user management
- protect password reset, activate/deactivate, delete, and bulk actions with the same server-side guard
- add focused regression tests for privileged-account protections

## Why
The user-management dashboard allowed a non-superuser with `users` manage scope to mutate privileged accounts. That created a direct escalation path where delegated managers could take over, disable, or otherwise alter superuser / `ADMIN` accounts.

## Root cause
The `users` views enforced only manage-scope access for the module and did not add a second guard for privileged targets. Once a caller had access to the user-management actions, the target account sensitivity was not checked before edit, reset-password, toggle-active, delete, or bulk mutations.

## Impact
- delegated user managers can no longer mutate `is_superuser` or `role=ADMIN` accounts through the dashboard
- bulk actions now skip privileged accounts for non-superusers and report that skip clearly
- the change is server-side, so it protects direct requests in addition to UI usage

## Validation
- `./scripts/run-django-test.ps1 -Target apps.users.tests.ProtectedUserManagementGuardsTest`

## Related
- Closes #71