### PR TITLE
[codex] Align users dashboard authorization

### DIFF
--- a/backend/apps/users/forms.py
+++ b/backend/apps/users/forms.py
@@ -34,6 +34,15 @@ def _clean_role_and_facility(form):
     return cleaned_data
 
 
+def _save_role_default_module_scopes(user, role):
+    for module_code, _ in ModuleAccess.Module.choices:
+        ModuleAccess.objects.update_or_create(
+            user=user,
+            module=module_code,
+            defaults={"scope": default_scope_for_role(role, module_code)},
+        )
+
+
 class UserCreateForm(forms.ModelForm):
     password1 = forms.CharField(
         label="Password",
@@ -63,10 +72,12 @@ class UserCreateForm(forms.ModelForm):
         }
 
     def __init__(self, *args, **kwargs):
+        self.can_manage_module_scopes = kwargs.pop("can_manage_module_scopes", True)
         super().__init__(*args, **kwargs)
         self.fields["role"].choices = UI_ROLE_CHOICES
         _configure_user_form_fields(self)
-        self._add_module_scope_fields()
+        if self.can_manage_module_scopes:
+            self._add_module_scope_fields()
 
     def _add_module_scope_fields(self):
         role = self.data.get("role") or self.initial.get("role") or User.Role.ADMIN_UMUM
@@ -116,7 +127,10 @@ class UserCreateForm(forms.ModelForm):
         user.set_password(self.cleaned_data["password1"])
         if commit:
             user.save()
-            self._save_module_scopes(user)
+            if self.can_manage_module_scopes:
+                self._save_module_scopes(user)
+            else:
+                _save_role_default_module_scopes(user, user.role)
         return user
 
     def _save_module_scopes(self, user):
@@ -148,6 +162,7 @@ class UserUpdateForm(forms.ModelForm):
         }
 
     def __init__(self, *args, **kwargs):
+        self.can_manage_module_scopes = kwargs.pop("can_manage_module_scopes", True)
         super().__init__(*args, **kwargs)
         # Only restrict role choices if the user is NOT already an ADMIN.
         # Existing ADMIN users can still be edited, but role cannot be
@@ -157,7 +172,8 @@ class UserUpdateForm(forms.ModelForm):
         ):
             self.fields["role"].choices = UI_ROLE_CHOICES
         _configure_user_form_fields(self)
-        self._add_module_scope_fields()
+        if self.can_manage_module_scopes:
+            self._add_module_scope_fields()
 
     def _add_module_scope_fields(self):
         role = self.data.get("role") or self.initial.get("role") or self.instance.role
@@ -209,7 +225,7 @@ class UserUpdateForm(forms.ModelForm):
 
     def save(self, commit=True):
         user = super().save(commit=commit)
-        if commit:
+        if commit and self.can_manage_module_scopes:
             for module_code, _ in ModuleAccess.Module.choices:
                 field_name = f"module_scope__{module_code}"
                 scope = int(self.cleaned_data.get(field_name, ModuleAccess.Scope.NONE))

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from apps.items.models import Facility
 from apps.users.access import (
     ROLE_DEFAULT_SCOPES,
+    default_scope_for_role,
     ensure_default_module_access,
     get_user_module_scope,
     has_module_permission,
@@ -52,7 +53,12 @@ class UserManagementViewsTest(TestCase):
         )
         self.client.force_login(admin_umum)
         response = self.client.get(reverse("users:user_list"))
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 403)
+        self.assertContains(
+            response,
+            "Anda tidak memiliki izin untuk membuka manajemen user.",
+            status_code=403,
+        )
 
     def test_kepala_can_access_user_management_but_cannot_edit(self):
         kepala = User.objects.create_user(
@@ -76,7 +82,12 @@ class UserManagementViewsTest(TestCase):
                 "is_active": "on",
             },
         )
-        self.assertEqual(edit_response.status_code, 302)
+        self.assertEqual(edit_response.status_code, 403)
+        self.assertContains(
+            edit_response,
+            "Anda tidak memiliki izin untuk mengubah user.",
+            status_code=403,
+        )
         self.target.refresh_from_db()
         self.assertNotEqual(self.target.full_name, "Tidak Boleh")
 
@@ -319,14 +330,14 @@ class UserManagementViewsTest(TestCase):
                 "password1": "BlockedReset123!",
                 "password2": "BlockedReset123!",
             },
-            follow=True,
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
         self.target.refresh_from_db()
         self.assertTrue(self.target.check_password("secret12345"))
-        self.assertIn(
+        self.assertContains(
+            response,
             "Anda tidak memiliki izin untuk mereset password user.",
-            [message.message for message in get_messages(response.wsgi_request)],
+            status_code=403,
         )
 
     def test_user_list_shows_nip(self):
@@ -447,7 +458,12 @@ class UserManagementViewsTest(TestCase):
 
         response = self.client.get(reverse("users:user_detail", args=[self.target.pk]))
 
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 403)
+        self.assertContains(
+            response,
+            "Anda tidak memiliki izin untuk membuka detail user.",
+            status_code=403,
+        )
 
     def test_bulk_action_activate_selected_users(self):
         inactive_user = User.objects.create_user(
@@ -760,6 +776,10 @@ class HybridUserAuthorizationTest(TestCase):
             content_type__app_label="users",
             codename="view_user",
         )
+        self.add_perm = Permission.objects.get(
+            content_type__app_label="users",
+            codename="add_user",
+        )
         self.change_perm = Permission.objects.get(
             content_type__app_label="users",
             codename="change_user",
@@ -785,6 +805,80 @@ class HybridUserAuthorizationTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, f"Edit User {self.target.username}")
+
+    def test_direct_django_add_permission_cannot_assign_custom_module_scopes(self):
+        self.viewer.user_permissions.add(self.add_perm)
+        self.client.force_login(self.viewer)
+
+        payload = {
+            "username": "limited_creator",
+            "full_name": "Limited Creator",
+            "nip": "197812312010011009",
+            "email": "limited_creator@example.com",
+            "role": User.Role.AUDITOR,
+            "is_active": "on",
+            "password1": "VeryStrongPass123!",
+            "password2": "VeryStrongPass123!",
+        }
+        payload.update(
+            {
+                f"module_scope__{module_code}": str(ModuleAccess.Scope.MANAGE)
+                for module_code, _ in ModuleAccess.Module.choices
+            }
+        )
+
+        response = self.client.post(reverse("users:user_create"), payload, secure=True)
+
+        self.assertEqual(response.status_code, 302)
+        created = User.objects.get(username="limited_creator")
+        self.assertEqual(
+            ModuleAccess.objects.get(
+                user=created,
+                module=ModuleAccess.Module.USERS,
+            ).scope,
+            default_scope_for_role(User.Role.AUDITOR, ModuleAccess.Module.USERS),
+        )
+
+    def test_direct_django_change_permission_cannot_override_existing_module_scopes(self):
+        self.editor.user_permissions.add(self.change_perm)
+        self.client.force_login(self.editor)
+        ModuleAccess.objects.update_or_create(
+            user=self.target,
+            module=ModuleAccess.Module.USERS,
+            defaults={"scope": ModuleAccess.Scope.VIEW},
+        )
+
+        payload = {
+            "username": self.target.username,
+            "full_name": "Updated Target User",
+            "nip": "",
+            "email": self.target.email,
+            "role": self.target.role,
+            "is_active": "on",
+        }
+        payload.update(
+            {
+                f"module_scope__{module_code}": str(ModuleAccess.Scope.MANAGE)
+                for module_code, _ in ModuleAccess.Module.choices
+            }
+        )
+
+        response = self.client.post(
+            reverse("users:user_update", args=[self.target.pk]),
+            payload,
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.target.refresh_from_db()
+        self.assertEqual(self.target.full_name, "Updated Target User")
+        self.assertEqual(
+            ModuleAccess.objects.get(
+                user=self.target,
+                module=ModuleAccess.Module.USERS,
+            ).scope,
+            ModuleAccess.Scope.VIEW,
+        )
 
     def test_missing_view_access_raises_403_instead_of_redirect(self):
         self.client.force_login(self.viewer)

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from django.contrib.auth.models import Permission
 from django.contrib.messages import get_messages
 from django.core.exceptions import ValidationError
 from django.db.models import ProtectedError
@@ -724,6 +725,115 @@ class UACRoleMatrixTest(TestCase):
         self.assertTrue(has_module_permission(user, "puskesmas.view_puskesmasrequest"))
 
 
+class HybridUserAuthorizationTest(TestCase):
+    def setUp(self):
+        self.viewer = User.objects.create_user(
+            username="viewer_only",
+            email="viewer_only@example.com",
+            password="VeryStrongPass123!",
+            role=User.Role.ADMIN_UMUM,
+        )
+        ModuleAccess.objects.update_or_create(
+            user=self.viewer,
+            module=ModuleAccess.Module.USERS,
+            defaults={"scope": ModuleAccess.Scope.NONE},
+        )
+        self.editor = User.objects.create_user(
+            username="editor_only",
+            email="editor_only@example.com",
+            password="VeryStrongPass123!",
+            role=User.Role.ADMIN_UMUM,
+        )
+        ModuleAccess.objects.update_or_create(
+            user=self.editor,
+            module=ModuleAccess.Module.USERS,
+            defaults={"scope": ModuleAccess.Scope.NONE},
+        )
+        self.target = User.objects.create_user(
+            username="target_user",
+            email="target_user@example.com",
+            password="VeryStrongPass123!",
+            role=User.Role.GUDANG,
+        )
+
+        self.view_perm = Permission.objects.get(
+            content_type__app_label="users",
+            codename="view_user",
+        )
+        self.change_perm = Permission.objects.get(
+            content_type__app_label="users",
+            codename="change_user",
+        )
+
+    def test_direct_django_view_permission_allows_user_list(self):
+        self.viewer.user_permissions.add(self.view_perm)
+        self.client.force_login(self.viewer)
+
+        response = self.client.get(reverse("users:user_list"), secure=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Manajemen Pengguna")
+
+    def test_direct_django_change_permission_allows_user_edit(self):
+        self.editor.user_permissions.add(self.change_perm)
+        self.client.force_login(self.editor)
+
+        response = self.client.get(
+            reverse("users:user_update", args=[self.target.pk]),
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f"Edit User {self.target.username}")
+
+    def test_missing_view_access_raises_403_instead_of_redirect(self):
+        self.client.force_login(self.viewer)
+
+        response = self.client.get(reverse("users:user_list"), secure=True)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertContains(
+            response,
+            "Anda tidak memiliki izin untuk membuka manajemen user.",
+            status_code=403,
+        )
+
+    def test_missing_add_access_raises_403_instead_of_redirect(self):
+        self.viewer.user_permissions.add(self.view_perm)
+        self.client.force_login(self.viewer)
+
+        response = self.client.get(reverse("users:user_create"), secure=True)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertContains(
+            response,
+            "Anda tidak memiliki izin untuk menambah user.",
+            status_code=403,
+        )
+
+    def test_missing_change_access_raises_403_for_password_reset(self):
+        self.viewer.user_permissions.add(self.view_perm)
+        self.client.force_login(self.viewer)
+
+        response = self.client.post(
+            reverse("users:user_reset_password", args=[self.target.pk]),
+            {
+                "password1": "BlockedReset123!",
+                "password2": "BlockedReset123!",
+            },
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.target.refresh_from_db()
+        self.assertTrue(self.target.check_password("VeryStrongPass123!"))
+        self.assertContains(
+            response,
+            "Anda tidak memiliki izin untuk mereset password user.",
+            status_code=403,
+        )
+
+
 class ProtectedUserManagementGuardsTest(TestCase):
     def setUp(self):
         self.super_admin = User.objects.create_superuser(
@@ -754,19 +864,13 @@ class ProtectedUserManagementGuardsTest(TestCase):
         response = self.client.get(
             reverse("users:user_update", args=[self.super_admin.pk]),
             secure=True,
-            follow=True,
         )
 
-        self.assertEqual(response.status_code, 200)
-        self.assertRedirects(
+        self.assertEqual(response.status_code, 403)
+        self.assertContains(
             response,
-            "https://testserver" + reverse("users:user_list"),
-            status_code=302,
-            target_status_code=200,
-        )
-        self.assertIn(
             "Akun admin hanya dapat dikelola oleh superuser.",
-            [message.message for message in get_messages(response.wsgi_request)],
+            status_code=403,
         )
 
     def test_non_superuser_cannot_reset_admin_password(self):
@@ -777,15 +881,15 @@ class ProtectedUserManagementGuardsTest(TestCase):
                 "password2": "ResetBlocked123!",
             },
             secure=True,
-            follow=True,
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
         self.super_admin.refresh_from_db()
         self.assertTrue(self.super_admin.check_password("VeryStrongPass123!"))
-        self.assertIn(
+        self.assertContains(
+            response,
             "Akun admin hanya dapat dikelola oleh superuser.",
-            [message.message for message in get_messages(response.wsgi_request)],
+            status_code=403,
         )
 
     def test_non_superuser_cannot_toggle_admin_active_status_via_ajax(self):
@@ -810,14 +914,14 @@ class ProtectedUserManagementGuardsTest(TestCase):
         response = self.client.post(
             reverse("users:user_delete", args=[self.super_admin.pk]),
             secure=True,
-            follow=True,
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
         self.assertTrue(User.objects.filter(pk=self.super_admin.pk).exists())
-        self.assertIn(
+        self.assertContains(
+            response,
             "Akun admin hanya dapat dikelola oleh superuser.",
-            [message.message for message in get_messages(response.wsgi_request)],
+            status_code=403,
         )
 
     def test_bulk_action_skips_admin_accounts_for_non_superuser_manager(self):

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -4,14 +4,14 @@ from django.contrib import messages
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.password_validation import validate_password
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.paginator import Paginator
 from django.db.models import ProtectedError
 from django.db.models import Q
 from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 
-from .access import ROLE_DEFAULT_SCOPES, has_module_scope
+from .access import ROLE_DEFAULT_SCOPES, has_module_permission
 from .forms import UserCreateForm, UserUpdateForm
 from .models import ModuleAccess, User
 
@@ -24,12 +24,24 @@ def _role_defaults_json():
     }
 
 
+def _has_user_access(user, perm):
+    return user.is_superuser or user.has_perm(perm) or has_module_permission(user, perm)
+
+
 def _can_view_users(user):
-    return has_module_scope(user, ModuleAccess.Module.USERS, ModuleAccess.Scope.VIEW)
+    return _has_user_access(user, "users.view_user")
 
 
-def _can_manage_users(user):
-    return has_module_scope(user, ModuleAccess.Module.USERS, ModuleAccess.Scope.MANAGE)
+def _can_add_users(user):
+    return _has_user_access(user, "users.add_user")
+
+
+def _can_change_users(user):
+    return _has_user_access(user, "users.change_user")
+
+
+def _can_delete_users(user):
+    return _has_user_access(user, "users.delete_user")
 
 
 def _protected_user_account_q():
@@ -40,17 +52,16 @@ def _is_protected_user_account(user_obj):
     return User.objects.filter(pk=user_obj.pk).filter(_protected_user_account_q()).exists()
 
 
-def _forbidden_manage_user(request, message):
-    messages.error(request, message)
-    return redirect("dashboard")
+def _require_user_access(user, perm, message):
+    if not _has_user_access(user, perm):
+        raise PermissionDenied(message)
 
 
 def _forbidden_protected_user_mutation(request, is_ajax=False):
     message = "Akun admin hanya dapat dikelola oleh superuser."
     if is_ajax:
         return JsonResponse({"success": False, "error": message}, status=403)
-    messages.error(request, message)
-    return redirect("users:user_list")
+    raise PermissionDenied(message)
 
 
 def _ensure_can_mutate_target_user(request, target_user, is_ajax=False):
@@ -94,11 +105,11 @@ def _effective_scope_rows(user_obj):
 
 @login_required
 def user_list(request):
-    if not _can_view_users(request.user):
-        return _forbidden_manage_user(
-            request,
-            "Anda tidak memiliki izin untuk membuka manajemen user.",
-        )
+    _require_user_access(
+        request.user,
+        "users.view_user",
+        "Anda tidak memiliki izin untuk membuka manajemen user.",
+    )
 
     queryset = User.objects.select_related("facility") \
         .only(
@@ -163,20 +174,20 @@ def user_list(request):
             "order": order,
             "sort_icon": sort_icon,
             "filter_params": filter_params.urlencode(),
-            "can_add_user": _can_manage_users(request.user),
-            "can_change_user": _can_manage_users(request.user),
-            "can_delete_user": _can_manage_users(request.user),
+            "can_add_user": _can_add_users(request.user),
+            "can_change_user": _can_change_users(request.user),
+            "can_delete_user": _can_delete_users(request.user),
         },
     )
 
 
 @login_required
 def user_create(request):
-    if not _can_manage_users(request.user):
-        return _forbidden_manage_user(
-            request,
-            "Anda tidak memiliki izin untuk menambah user.",
-        )
+    _require_user_access(
+        request.user,
+        "users.add_user",
+        "Anda tidak memiliki izin untuk menambah user.",
+    )
 
     if request.method == "POST":
         form = UserCreateForm(request.POST)
@@ -200,11 +211,11 @@ def user_create(request):
 
 @login_required
 def user_update(request, pk):
-    if not _can_manage_users(request.user):
-        return _forbidden_manage_user(
-            request,
-            "Anda tidak memiliki izin untuk mengubah user.",
-        )
+    _require_user_access(
+        request.user,
+        "users.change_user",
+        "Anda tidak memiliki izin untuk mengubah user.",
+    )
 
     target_user = get_object_or_404(User, pk=pk)
     protected_response = _ensure_can_mutate_target_user(request, target_user)
@@ -237,13 +248,12 @@ def user_update(request, pk):
 def user_toggle_active(request, pk):
     is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
 
-    if not _can_manage_users(request.user):
+    if not _can_change_users(request.user):
         if is_ajax:
-            return JsonResponse({"success": False, "error": "Tidak memiliki izin."}, status=403)
-        return _forbidden_manage_user(
-            request,
-            "Anda tidak memiliki izin untuk mengubah status user.",
-        )
+            return JsonResponse(
+                {"success": False, "error": "Tidak memiliki izin."}, status=403
+            )
+        raise PermissionDenied("Anda tidak memiliki izin untuk mengubah status user.")
 
     target_user = get_object_or_404(User, pk=pk)
     protected_response = _ensure_can_mutate_target_user(
@@ -284,11 +294,11 @@ def user_toggle_active(request, pk):
 
 @login_required
 def user_delete(request, pk):
-    if not _can_manage_users(request.user):
-        return _forbidden_manage_user(
-            request,
-            "Anda tidak memiliki izin untuk menghapus user.",
-        )
+    _require_user_access(
+        request.user,
+        "users.delete_user",
+        "Anda tidak memiliki izin untuk menghapus user.",
+    )
 
     target_user = get_object_or_404(User, pk=pk)
     protected_response = _ensure_can_mutate_target_user(request, target_user)
@@ -324,11 +334,11 @@ def user_delete(request, pk):
 
 @login_required
 def user_detail(request, pk):
-    if not _can_view_users(request.user):
-        return _forbidden_manage_user(
-            request,
-            "Anda tidak memiliki izin untuk membuka detail user.",
-        )
+    _require_user_access(
+        request.user,
+        "users.view_user",
+        "Anda tidak memiliki izin untuk membuka detail user.",
+    )
 
     target_user = get_object_or_404(
         User.objects.select_related("facility").prefetch_related("module_accesses"),
@@ -341,23 +351,23 @@ def user_detail(request, pk):
         {
             "target_user": target_user,
             "effective_scopes": _effective_scope_rows(target_user),
-            "can_manage_users": _can_manage_users(request.user),
+            "can_manage_users": _can_change_users(request.user),
         },
     )
 
 
 @login_required
 def user_bulk_action(request):
-    if not _can_manage_users(request.user):
-        return _forbidden_manage_user(
-            request,
-            "Anda tidak memiliki izin untuk aksi massal.",
-        )
-
     if request.method != "POST":
         return redirect("users:user_list")
 
     action = request.POST.get("action", "")
+    required_perm = "users.delete_user" if action == "delete" else "users.change_user"
+    _require_user_access(
+        request.user,
+        required_perm,
+        "Anda tidak memiliki izin untuk aksi massal.",
+    )
     pks = request.POST.getlist("selected_users", [])
 
     if not pks:
@@ -447,11 +457,11 @@ def user_bulk_action(request):
 
 @login_required
 def user_reset_password(request, pk):
-    if not _can_manage_users(request.user):
-        return _forbidden_manage_user(
-            request,
-            "Anda tidak memiliki izin untuk mereset password user.",
-        )
+    _require_user_access(
+        request.user,
+        "users.change_user",
+        "Anda tidak memiliki izin untuk mereset password user.",
+    )
 
     target_user = get_object_or_404(User, pk=pk)
     protected_response = _ensure_can_mutate_target_user(request, target_user)
@@ -526,11 +536,11 @@ def _build_user_export_queryset(request):
 
 @login_required
 def user_export_csv(request):
-    if not _can_view_users(request.user):
-        return _forbidden_manage_user(
-            request,
-            "Anda tidak memiliki izin untuk mengekspor data pengguna.",
-        )
+    _require_user_access(
+        request.user,
+        "users.view_user",
+        "Anda tidak memiliki izin untuk mengekspor data pengguna.",
+    )
 
     queryset = _build_user_export_queryset(request)
     role_map = dict(User.Role.choices)

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -44,6 +44,10 @@ def _can_delete_users(user):
     return _has_user_access(user, "users.delete_user")
 
 
+def _can_manage_user_scopes(user):
+    return user.is_superuser or has_module_permission(user, "users.change_user")
+
+
 def _protected_user_account_q():
     return Q(is_superuser=True) | Q(role=User.Role.ADMIN)
 
@@ -188,15 +192,19 @@ def user_create(request):
         "users.add_user",
         "Anda tidak memiliki izin untuk menambah user.",
     )
+    can_manage_user_scopes = _can_manage_user_scopes(request.user)
 
     if request.method == "POST":
-        form = UserCreateForm(request.POST)
+        form = UserCreateForm(
+            request.POST,
+            can_manage_module_scopes=can_manage_user_scopes,
+        )
         if form.is_valid():
             user = form.save()
             messages.success(request, f"User {user.username} berhasil ditambahkan.")
             return redirect("users:user_list")
     else:
-        form = UserCreateForm()
+        form = UserCreateForm(can_manage_module_scopes=can_manage_user_scopes)
 
     return render(
         request,
@@ -205,6 +213,7 @@ def user_create(request):
             "form": form,
             "title": "Tambah User",
             "role_defaults_json": _role_defaults_json(),
+            "can_manage_user_scopes": can_manage_user_scopes,
         },
     )
 
@@ -216,6 +225,7 @@ def user_update(request, pk):
         "users.change_user",
         "Anda tidak memiliki izin untuk mengubah user.",
     )
+    can_manage_user_scopes = _can_manage_user_scopes(request.user)
 
     target_user = get_object_or_404(User, pk=pk)
     protected_response = _ensure_can_mutate_target_user(request, target_user)
@@ -223,13 +233,20 @@ def user_update(request, pk):
         return protected_response
 
     if request.method == "POST":
-        form = UserUpdateForm(request.POST, instance=target_user)
+        form = UserUpdateForm(
+            request.POST,
+            instance=target_user,
+            can_manage_module_scopes=can_manage_user_scopes,
+        )
         if form.is_valid():
             user = form.save()
             messages.success(request, f"User {user.username} berhasil diperbarui.")
             return redirect("users:user_list")
     else:
-        form = UserUpdateForm(instance=target_user)
+        form = UserUpdateForm(
+            instance=target_user,
+            can_manage_module_scopes=can_manage_user_scopes,
+        )
 
     return render(
         request,
@@ -240,6 +257,7 @@ def user_update(request, pk):
             "target_user": target_user,
             "effective_scopes": _effective_scope_rows(target_user),
             "role_defaults_json": _role_defaults_json(),
+            "can_manage_user_scopes": can_manage_user_scopes,
         },
     )
 

--- a/backend/templates/users/user_form.html
+++ b/backend/templates/users/user_form.html
@@ -79,12 +79,14 @@
                                 <span class="badge bg-danger-subtle text-danger ms-1 tab-error-count d-none" id="profilErrorCount">0</span>
                             </button>
                         </li>
+                        {% if can_manage_user_scopes %}
                         <li class="nav-item" role="presentation">
                             <button class="nav-link" id="akses-tab" data-bs-toggle="tab" data-bs-target="#aksesPane" type="button" role="tab" aria-selected="false">
                                 <i class="bi bi-shield-lock me-1"></i>Akses Modul
                                 <span class="badge bg-danger-subtle text-danger ms-1 tab-error-count d-none" id="aksesErrorCount">0</span>
                             </button>
                         </li>
+                        {% endif %}
                     </ul>
 
                     <!-- Tab Content -->
@@ -159,6 +161,7 @@
                         </div>
 
                         <!-- UAC Tab -->
+                        {% if can_manage_user_scopes %}
                         <div class="tab-pane fade" id="aksesPane" role="tabpanel">
                             <div class="d-flex justify-content-between align-items-center mb-2">
                                 <h6 class="mb-0">Akses Modul (UAC)</h6>
@@ -218,6 +221,7 @@
                                 </table>
                             </div>
                         </div>
+                        {% endif %}
                     </div>
 
                     <!-- Sticky Footer -->
@@ -270,6 +274,7 @@
 </div>
 {% endif %}
 
+{% if can_manage_user_scopes %}
 <div class="modal fade" id="scopeInfoModal" tabindex="-1" aria-labelledby="scopeInfoModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-scrollable">
         <div class="modal-content">
@@ -318,6 +323,7 @@
         </div>
     </div>
 </div>
+{% endif %}
 
 {{ role_defaults_json|json_script:"role-defaults-data" }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- align `users` dashboard access checks with the repository's hybrid authorization model
- honor direct Django permissions for user-management actions in addition to module-scope fallback
- raise `PermissionDenied` for normal authorization failures so requests flow through the centralized 403 handler
- update focused tests for the new 403 behavior and add direct Django-permission coverage

## Why
The `users` dashboard had drifted from the repository's documented authorization contract. It checked only module scope and redirected with flash messages on denial, which meant group-granted Django permissions were ignored and authorization failures bypassed the standard 403 flow.

## Root cause
The view layer in `backend/apps/users/views.py` used local `has_module_scope()` checks instead of the documented hybrid permission path. It also handled denials locally by redirecting rather than raising `PermissionDenied`.

## Impact
- group-granted Django permissions now work for `view`, `add`, `change`, and `delete` user-management actions
- user-management denials now render through the centralized 403 handler and produce consistent security logging
- button visibility in the dashboard now follows the actual per-action authorization checks more closely
- privileged-account protections from the earlier fix still apply and now use the same 403 flow for non-AJAX requests

## Validation
- `./scripts/run-django-test.ps1 -Target apps.users.tests.HybridUserAuthorizationTest`
- `./scripts/run-django-test.ps1 -Target apps.users.tests.ProtectedUserManagementGuardsTest`

## Related
- Closes #73