### PR TITLE
Fix LPLPO super admin access and stock carry-over

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ Default scopes per role are defined in `backend/apps/users/access.py`.
 ### Specialized Roles (e.g. OPERATOR PUSKESMAS)
 
 - `OPERATOR PUSKESMAS` role uses `facility` matching. Views in `puskesmas` and `lplpo` enforce strict facility isolation so that operators from one facility cannot read/write another facility's documents.
+- Super Admin (`is_superuser` / role `ADMIN`) is exempt from facility scoping in `lplpo` and may create, edit, submit, and delete LPLPO across all Puskesmas facilities.
 
 ## Workflow and Data Mutation Rules
 
@@ -97,6 +98,7 @@ Default scopes per role are defined in `backend/apps/users/access.py`.
 - Receiving admin CSV import writes `Receiving`, `ReceivingItem`, updates/creates `Stock`, and writes `Transaction(IN)`.
 - Receiving supports built-in and custom type codes; UI labels for non-built-in types are resolved from `ReceivingTypeOption`.
 - `Distribution(distribution_type=LPLPO)` is system-generated from `lplpo_finalize`; do not expose it as a manual distribution type in the generic distribution create/edit flow.
+- LPLPO creation auto-fills `stock_awal` from the immediately previous month's LPLPO for the same facility when one exists and is not `REJECTED`; the carry-over no longer waits for the prior document to reach `CLOSED`.
 - Distribution numbering templates for `LPLPO` and `SPECIAL_REQUEST` are user-configurable through `SystemSettings`; supported placeholders are `{seq}` and `{year}` and sequence counters remain scoped per distribution type and matched against the active template.
 - `Distribution(distribution_type=ALLOCATION)` is system-generated from `allocation` approval; one per facility, starts in `VERIFIED` status, quantities are locked and cannot be edited.
 - Allocation approval atomically creates `Distribution` + `DistributionItem` records for each facility. Stepping an allocation back from `APPROVED` to `SUBMITTED` deletes those child distributions so they can be regenerated on the next approval. Stock deduction is deferred to per-distribution delivery confirmation.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Solusi ini membantu proses inventaris berjalan lebih konsisten melalui alur doku
 - Pencatatan stok per batch dengan pendekatan FEFO agar distribusi lebih terkendali dan masa kedaluwarsa lebih mudah dipantau.
 - Alur kerja end-to-end untuk penerimaan, distribusi, recall, barang kedaluwarsa, transfer stok, dan stock opname.
 - Dukungan tipe penerimaan bawaan dan tipe kustom melalui `ReceivingTypeOption`, termasuk quick-create dari form penerimaan.
-- Pelaporan LPLPO bulanan dan pengajuan permintaan barang secara ad-hoc dari Puskesmas.
+- Pelaporan LPLPO bulanan dan pengajuan permintaan barang secara ad-hoc dari Puskesmas, termasuk carry-over `sisa stok` bulan sebelumnya ke `stock_awal` bulan berikutnya selama dokumen bulan sebelumnya tidak berstatus `REJECTED`.
 - Log `Transaction` yang imutabel untuk seluruh pergerakan stok, sehingga histori tetap terjaga.
 - Pengendalian akses melalui kombinasi permission Django dan `ModuleAccess` per pengguna.
 - Dukungan import CSV dari Django Admin, termasuk endpoint khusus untuk penerimaan barang yang mengelompokkan baris per `document_number` dan langsung membentuk stok serta `Transaction(IN)`.
@@ -44,6 +44,7 @@ Solusi ini membantu proses inventaris berjalan lebih konsisten melalui alur doku
 - `stock_opname`: proses hitung fisik dan cetak laporan selisih.
 - `puskesmas`: pengajuan permintaan barang ad-hoc dari unit Puskesmas.
 - `lplpo`: pelaporan pemakaian dan permintaan rutin bulanan dari Puskesmas.
+  Super Admin dapat mengelola LPLPO lintas fasilitas, sementara operator Puskesmas tetap dibatasi ke fasilitasnya sendiri.
 - `users`: manajemen pengguna dan pengaturan cakupan akses modul.
 
 - `core`: dashboard, middleware akses panel admin, pengaturan sistem (label platform login, logo, header dokumen, nama fasilitas, serta template penomoran dokumen distribusi) secara dinamis, placeholder riwayat administrasi terpisah untuk penerimaan serta pengeluaran, dan handler error terpusat untuk `400/403/404/500` plus halaman maintenance `503`.

--- a/SYSTEM_MODEL.md
+++ b/SYSTEM_MODEL.md
@@ -55,6 +55,8 @@ Module highlights:
 - Expiry alerts: `/expired/alerts/`
 - Reports: `/reports/`, `/reports/riwayat-penomoran/`, `/reports/rekap/`, `/reports/penerimaan-hibah/`, `/reports/pengadaan/`, `/reports/kadaluarsa/`, `/reports/pengeluaran/`
 - LPLPO: `/lplpo/` (All), `/lplpo/my/` (Puskesmas scoped), `/lplpo/create/`, `/lplpo/print-report/`, `/lplpo/api/prefill-penerimaan/`, `/lplpo/<pk>/`, `/lplpo/<pk>/edit/`, `/lplpo/<pk>/submit/`, `/lplpo/<pk>/reject/`, `/lplpo/<pk>/review/`, `/lplpo/<pk>/finalize/`, `/lplpo/<pk>/delete/`, `/lplpo/<pk>/print/`
+  - Super Admin sees all statuses on `/lplpo/` and can perform create/edit/submit/delete across facilities.
+  - Non-Puskesmas non-superuser staff continue to use `/lplpo/` as the submitted queue only.
 - Puskesmas requests: `/puskesmas/permintaan/`, `/puskesmas/permintaan/buat/`, `/puskesmas/permintaan/<pk>/`, `/puskesmas/permintaan/<pk>/edit/`, `/puskesmas/permintaan/<pk>/delete/`, `/puskesmas/permintaan/<pk>/submit/`, `/puskesmas/permintaan/<pk>/approve/`, `/puskesmas/permintaan/<pk>/reject/`, `/puskesmas/permintaan/<pk>/reset-draft/`
 - Allocation: `/allocation/`, `/allocation/create/`, `/allocation/<pk>/`, `/allocation/<pk>/edit/`, `/allocation/<pk>/delete/`, `/allocation/<pk>/reset-to-draft/`, `/allocation/<pk>/submit/`, `/allocation/<pk>/approve/`, `/allocation/<pk>/step-back/`, `/allocation/<pk>/reject/`, `/allocation/<pk>/distributions/<dist_pk>/prepare/`, `/allocation/<pk>/distributions/<dist_pk>/deliver/`
 
@@ -78,6 +80,7 @@ Permission denials are expected to raise `PermissionDenied` so the centralized 4
 Special rule:
 
 - For `users.*` permissions, non-view actions require `MANAGE` scope.
+- `lplpo` facility isolation applies only to `PUSKESMAS` users; Super Admin users (`is_superuser`) can access and mutate LPLPO across all facilities.
 
 Role default scopes are seeded in `backend/apps/users/access.py` via `ROLE_DEFAULT_SCOPES`.
 
@@ -315,6 +318,7 @@ This section reflects model code in `backend/apps/*/models.py`.
   - Computed fields (auto): `persediaan`, `stock_keseluruhan`, `stock_optimum`, `jumlah_kebutuhan`
   - IF fields: `pemberian_jumlah` (nullable), `pemberian_alasan`
   - Audit: `penerimaan_auto_filled`
+  - Create flow auto-fills `stock_awal` from the previous month's LPLPO for the same facility when that prior document exists and is not `REJECTED`
 
 ## 5) Stock Mutation Checkpoints
 

--- a/backend/apps/lplpo/forms.py
+++ b/backend/apps/lplpo/forms.py
@@ -1,12 +1,28 @@
 import calendar
+import unicodedata
 from decimal import ROUND_HALF_UP
 
 from django import forms
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 
 from apps.users.models import User
 
 from .models import LPLPOItem
+
+
+def _normalize_text_value(value, *, field_label, max_length=None):
+    if value in (None, ""):
+        return ""
+
+    normalized = unicodedata.normalize("NFC", value).strip()
+    if "\x00" in normalized:
+        raise ValidationError(f"{field_label} tidak boleh mengandung null byte.")
+    if max_length is not None and len(normalized) > max_length:
+        raise ValidationError(
+            f"{field_label} tidak boleh lebih dari {max_length} karakter."
+        )
+    return normalized
 
 
 class LPLPOCreateForm(forms.Form):
@@ -39,6 +55,7 @@ class LPLPOCreateForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user", None)
+        self.user = user
         super().__init__(*args, **kwargs)
         from apps.items.models import Facility
 
@@ -48,6 +65,26 @@ class LPLPOCreateForm(forms.Form):
         if user and getattr(user, "role", None) == User.Role.PUSKESMAS:
             self.fields["facility"].widget = forms.HiddenInput()
             self.fields["facility"].required = False
+
+    def clean_tahun(self):
+        tahun = self.cleaned_data["tahun"]
+        if tahun < 1000 or tahun > 9999:
+            raise ValidationError("Tahun harus berada di antara 1000 dan 9999.")
+        return tahun
+
+    def clean_notes(self):
+        return _normalize_text_value(
+            self.cleaned_data.get("notes"),
+            field_label="Catatan",
+            max_length=1000,
+        )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        user_role = getattr(self.user, "role", None)
+        if user_role != User.Role.PUSKESMAS and not cleaned_data.get("facility"):
+            self.add_error("facility", "Fasilitas puskesmas wajib dipilih.")
+        return cleaned_data
 
 
 class LPLPOItemPuskesmasForm(forms.ModelForm):
@@ -69,6 +106,13 @@ class LPLPOItemPuskesmasForm(forms.ModelForm):
         if value in (None, ""):
             return 0
         return value
+
+    def clean_permintaan_alasan(self):
+        return _normalize_text_value(
+            self.cleaned_data.get("permintaan_alasan"),
+            field_label="Alasan",
+            max_length=1000,
+        )
 
     class Meta:
         model = LPLPOItem
@@ -128,6 +172,13 @@ class LPLPOItemReviewForm(forms.ModelForm):
             ),
         }
 
+    def clean_pemberian_alasan(self):
+        return _normalize_text_value(
+            self.cleaned_data.get("pemberian_alasan"),
+            field_label="Alasan pemberian",
+            max_length=1000,
+        )
+
 
 class RejectLPLPOForm(forms.Form):
     """Form for Instalasi Farmasi to provide a rejection reason."""
@@ -138,3 +189,10 @@ class RejectLPLPOForm(forms.Form):
         label="Alasan Penolakan",
         error_messages={"required": "Alasan penolakan wajib diisi."},
     )
+
+    def clean_rejection_reason(self):
+        return _normalize_text_value(
+            self.cleaned_data.get("rejection_reason"),
+            field_label="Alasan penolakan",
+            max_length=1000,
+        )

--- a/backend/apps/lplpo/forms.py
+++ b/backend/apps/lplpo/forms.py
@@ -66,12 +66,6 @@ class LPLPOCreateForm(forms.Form):
             self.fields["facility"].widget = forms.HiddenInput()
             self.fields["facility"].required = False
 
-    def clean_tahun(self):
-        tahun = self.cleaned_data["tahun"]
-        if tahun < 1000 or tahun > 9999:
-            raise ValidationError("Tahun harus berada di antara 1000 dan 9999.")
-        return tahun
-
     def clean_notes(self):
         return _normalize_text_value(
             self.cleaned_data.get("notes"),

--- a/backend/apps/lplpo/models.py
+++ b/backend/apps/lplpo/models.py
@@ -274,7 +274,7 @@ def get_penerimaan_for_facility_period(facility, bulan, tahun):
 
 
 def get_previous_lplpo(facility, bulan, tahun):
-    """Return the previous month's CLOSED LPLPO for stock_awal auto-fill."""
+    """Return the previous month's usable LPLPO for stock_awal auto-fill."""
     prev_bulan = bulan - 1
     prev_tahun = tahun
     if prev_bulan < 1:
@@ -286,7 +286,9 @@ def get_previous_lplpo(facility, bulan, tahun):
             facility=facility,
             bulan=prev_bulan,
             tahun=prev_tahun,
-            status=LPLPO.Status.CLOSED,
+        )
+        .exclude(
+            status=LPLPO.Status.REJECTED,
         )
         .first()
     )

--- a/backend/apps/lplpo/tests.py
+++ b/backend/apps/lplpo/tests.py
@@ -934,6 +934,22 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 		self.assertContains(response, matching.document_number)
 		self.assertNotContains(response, non_matching.document_number)
 
+	def test_super_admin_print_report_still_only_shows_submitted_documents(self):
+		draft_lplpo = self.create_lplpo(status=LPLPO.Status.DRAFT)
+		submitted_lplpo = self.create_lplpo(
+			status=LPLPO.Status.SUBMITTED,
+			bulan=3,
+			tahun=2026,
+		)
+		self.set_submitted_at(submitted_lplpo, 2026, 4, 5)
+
+		self.client.force_login(self.superuser)
+		response = self.client.get(reverse("lplpo:lplpo_print_report"))
+
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, submitted_lplpo.document_number)
+		self.assertNotContains(response, draft_lplpo.document_number)
+
 	def test_distribution_distributed_closes_lplpo(self):
 		distribution = Distribution.objects.create(
 			distribution_type=Distribution.DistributionType.LPLPO,

--- a/backend/apps/lplpo/tests.py
+++ b/backend/apps/lplpo/tests.py
@@ -156,7 +156,7 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 		self.assertTrue(all(item.pemberian_jumlah is None for item in items))
 
 	def test_instalasi_farmasi_cannot_create_lplpo(self):
-		self.client.force_login(self.staff_user)
+		self.client.force_login(self.gudang_user)
 
 		response = self.client.get(reverse("lplpo:lplpo_create"))
 
@@ -167,14 +167,14 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 			status_code=403,
 		)
 
-	def test_instalasi_farmasi_list_hides_create_button(self):
-		self.client.force_login(self.staff_user)
+	def test_super_admin_list_shows_create_button(self):
+		self.client.force_login(self.superuser)
 
 		response = self.client.get(reverse("lplpo:lplpo_list"))
 
 		self.assertEqual(response.status_code, 200)
-		self.assertNotContains(response, 'id="create-lplpo-btn"')
-		self.assertContains(response, 'id="print-report-btn"')
+		self.assertContains(response, 'id="create-lplpo-btn"')
+		self.assertNotContains(response, 'id="print-report-btn"')
 
 	def test_instalasi_farmasi_list_only_shows_submitted_documents(self):
 		draft_lplpo = self.create_lplpo(status=LPLPO.Status.DRAFT)
@@ -185,12 +185,28 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 		)
 		self.set_submitted_at(submitted_lplpo, 2026, 4, 5)
 
-		self.client.force_login(self.staff_user)
+		self.client.force_login(self.gudang_user)
 		response = self.client.get(reverse("lplpo:lplpo_list"))
 
 		self.assertEqual(response.status_code, 200)
 		self.assertContains(response, submitted_lplpo.document_number)
 		self.assertNotContains(response, draft_lplpo.document_number)
+
+	def test_super_admin_list_shows_draft_and_submitted_documents(self):
+		draft_lplpo = self.create_lplpo(status=LPLPO.Status.DRAFT)
+		submitted_lplpo = self.create_lplpo(
+			bulan=3,
+			tahun=2026,
+			status=LPLPO.Status.SUBMITTED,
+		)
+		self.set_submitted_at(submitted_lplpo, 2026, 4, 5)
+
+		self.client.force_login(self.superuser)
+		response = self.client.get(reverse("lplpo:lplpo_list"))
+
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, draft_lplpo.document_number)
+		self.assertContains(response, submitted_lplpo.document_number)
 
 	def test_instalasi_farmasi_list_filters_by_submission_month_and_year(self):
 		march_submission = self.create_lplpo(status=LPLPO.Status.SUBMITTED, bulan=2, tahun=2026)
@@ -199,7 +215,7 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 		april_submission = self.create_lplpo(status=LPLPO.Status.SUBMITTED, bulan=3, tahun=2026)
 		self.set_submitted_at(april_submission, 2026, 4, 10)
 
-		self.client.force_login(self.staff_user)
+		self.client.force_login(self.gudang_user)
 		response = self.client.get(
 			reverse("lplpo:lplpo_list"),
 			{"submitted_month": "4", "submitted_year": "2026"},
@@ -271,6 +287,25 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 		self.assertEqual(
 			current.items.get(item=self.item_b).stock_awal,
 			Decimal("5.00"),
+		)
+
+	def test_stock_awal_from_previous_submitted_lplpo(self):
+		previous = self.create_lplpo(bulan=1, tahun=2026, status=LPLPO.Status.SUBMITTED)
+		LPLPOItem.objects.create(
+			lplpo=previous,
+			item=self.item_a,
+			stock_awal=Decimal("6.00"),
+			penerimaan=Decimal("4.00"),
+			pemakaian=Decimal("3.00"),
+		)
+
+		self.client.force_login(self.puskesmas_user)
+		self.client.post(reverse("lplpo:lplpo_create"), {"bulan": "2", "tahun": "2026"})
+
+		current = LPLPO.objects.get(facility=self.facility, bulan=2, tahun=2026)
+		self.assertEqual(
+			current.items.get(item=self.item_a).stock_awal,
+			Decimal("7.00"),
 		)
 
 	def test_edit_renders_previous_stock_awal_without_decimal_places(self):
@@ -530,6 +565,17 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 		self.assertNotContains(response, 'id="submit-btn"')
 		self.assertNotContains(response, 'id="delete-btn"')
 
+	def test_super_admin_detail_shows_draft_mutation_actions(self):
+		lplpo = self.create_lplpo()
+
+		self.client.force_login(self.superuser)
+		response = self.client.get(reverse("lplpo:lplpo_detail", args=[lplpo.pk]))
+
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, 'id="edit-btn"')
+		self.assertContains(response, 'id="submit-btn"')
+		self.assertContains(response, 'id="delete-btn"')
+
 	def test_non_puskesmas_cannot_delete_draft_lplpo(self):
 		lplpo = self.create_lplpo()
 
@@ -543,6 +589,76 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 			status_code=403,
 		)
 		self.assertTrue(LPLPO.objects.filter(pk=lplpo.pk).exists())
+
+	def test_super_admin_can_create_lplpo_for_any_puskesmas(self):
+		self.client.force_login(self.superuser)
+
+		response = self.client.post(
+			reverse("lplpo:lplpo_create"),
+			{
+				"bulan": "2",
+				"tahun": "2026",
+				"facility": str(self.other_facility.pk),
+				"notes": " Dibuat admin pusat ",
+			},
+		)
+
+		self.assertEqual(response.status_code, 302)
+		lplpo = LPLPO.objects.get(facility=self.other_facility, bulan=2, tahun=2026)
+		self.assertEqual(lplpo.created_by, self.superuser)
+		self.assertEqual(lplpo.notes, "Dibuat admin pusat")
+
+	def test_super_admin_can_edit_submit_and_delete_draft_lplpo(self):
+		lplpo = self.create_lplpo(
+			facility=self.other_facility,
+			created_by=self.other_puskesmas_user,
+		)
+		line = LPLPOItem.objects.create(
+			lplpo=lplpo,
+			item=self.item_a,
+			stock_awal=Decimal("1.00"),
+			penerimaan=Decimal("2.00"),
+			pemakaian=Decimal("1.00"),
+		)
+
+		self.client.force_login(self.superuser)
+		edit_response = self.client.post(
+			reverse("lplpo:lplpo_edit", args=[lplpo.pk]),
+			{
+				f"item_{line.pk}-stock_awal": "5",
+				f"item_{line.pk}-penerimaan": "3",
+				f"item_{line.pk}-pembelian_puskesmas": "1",
+				f"item_{line.pk}-pemakaian": "2",
+				f"item_{line.pk}-stock_gudang_puskesmas": "1",
+				f"item_{line.pk}-waktu_kosong": "0",
+				f"item_{line.pk}-permintaan_jumlah": "4",
+				f"item_{line.pk}-permintaan_alasan": " Buffer ",
+			},
+		)
+		self.assertEqual(edit_response.status_code, 302)
+
+		line.refresh_from_db()
+		self.assertEqual(line.stock_awal, Decimal("5.00"))
+		self.assertEqual(line.permintaan_alasan, "Buffer")
+
+		submit_response = self.client.post(reverse("lplpo:lplpo_submit", args=[lplpo.pk]))
+		self.assertEqual(submit_response.status_code, 302)
+		lplpo.refresh_from_db()
+		self.assertEqual(lplpo.status, LPLPO.Status.SUBMITTED)
+		self.assertIsNotNone(lplpo.submitted_at)
+
+		draft_for_delete = self.create_lplpo(
+			facility=self.other_facility,
+			created_by=self.other_puskesmas_user,
+			bulan=3,
+			tahun=2026,
+		)
+		delete_pk = draft_for_delete.pk
+		delete_response = self.client.post(
+			reverse("lplpo:lplpo_delete", args=[delete_pk])
+		)
+		self.assertEqual(delete_response.status_code, 302)
+		self.assertFalse(LPLPO.objects.filter(pk=delete_pk).exists())
 
 	def test_unique_constraint_facility_period(self):
 		self.create_lplpo(bulan=2, tahun=2026)

--- a/backend/apps/lplpo/views.py
+++ b/backend/apps/lplpo/views.py
@@ -1,6 +1,7 @@
 from datetime import date
 from decimal import Decimal
 import calendar
+import logging
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -23,6 +24,12 @@ from apps.users.models import ModuleAccess, User
 from .forms import LPLPOCreateForm, LPLPOItemPuskesmasForm, LPLPOItemReviewForm, RejectLPLPOForm
 from .models import LPLPO, LPLPOItem, get_penerimaan_for_facility_period, get_previous_lplpo
 
+logger = logging.getLogger(__name__)
+
+
+def _is_super_admin(user):
+    return bool(getattr(user, "is_superuser", False))
+
 
 def _check_facility_access(request, lplpo_obj):
     """
@@ -30,7 +37,7 @@ def _check_facility_access(request, lplpo_obj):
     to access an LPLPO that belongs to a different facility.
     Returns None if access is allowed.
     """
-    if request.user.role != User.Role.PUSKESMAS:
+    if _is_super_admin(request.user) or request.user.role != User.Role.PUSKESMAS:
         return None  # Non-puskesmas roles can see all
     if not request.user.facility:
         messages.error(request, "Akun Anda belum terhubung ke fasilitas.")
@@ -53,13 +60,17 @@ def _check_instalasi_farmasi_access(request):
 
 
 def _check_puskesmas_creator_access(request):
-    """Restrict create flow to PUSKESMAS operators only."""
+    """Restrict create flow to PUSKESMAS operators and super admin."""
+    if _is_super_admin(request.user):
+        return
     if request.user.role != User.Role.PUSKESMAS:
         raise PermissionDenied("Hanya operator Puskesmas yang dapat membuat LPLPO.")
 
 
 def _check_puskesmas_draft_action_access(request):
-    """Restrict draft LPLPO mutations to PUSKESMAS operators only."""
+    """Restrict draft LPLPO mutations to PUSKESMAS operators and super admin."""
+    if _is_super_admin(request.user):
+        return
     if request.user.role != User.Role.PUSKESMAS:
         raise PermissionDenied(
             "Hanya operator Puskesmas yang dapat mengubah LPLPO draft."
@@ -71,11 +82,12 @@ def _get_submission_month_choices():
 
 
 def _get_submitted_lplpo_queryset(request):
-    queryset = (
-        LPLPO.objects.select_related("facility", "created_by", "reviewed_by")
-        .filter(submitted_at__isnull=False)
-        .order_by("-submitted_at", "-tahun", "-bulan", "facility__name")
+    queryset = LPLPO.objects.select_related(
+        "facility", "created_by", "reviewed_by", "distribution"
     )
+    if not _is_super_admin(request.user):
+        queryset = queryset.filter(submitted_at__isnull=False)
+    queryset = queryset.order_by("-submitted_at", "-tahun", "-bulan", "facility__name")
 
     q = request.GET.get("q", "").strip()
     if q:
@@ -127,6 +139,7 @@ def lplpo_list(request):
             "lplpos": page,
             **filter_context,
             "is_all": True,
+            "can_manage_all_lplpo": _is_super_admin(request.user),
         },
     )
 
@@ -186,7 +199,7 @@ def lplpo_create(request):
 
             # Determine facility
             facility = request.user.facility
-            if not facility:
+            if _is_super_admin(request.user) or not facility:
                 facility = form.cleaned_data.get("facility")
 
             if not facility:
@@ -251,6 +264,17 @@ def lplpo_create(request):
 
                 LPLPOItem.objects.bulk_create(lplpo_items)
 
+            if _is_super_admin(request.user):
+                logger.info(
+                    "super_admin_created_lplpo",
+                    extra={
+                        "user_id": request.user.pk,
+                        "facility_id": facility.pk,
+                        "lplpo_id": lplpo.pk,
+                        "bulan": bulan,
+                        "tahun": tahun,
+                    },
+                )
             messages.success(
                 request,
                 f"LPLPO {lplpo.document_number} berhasil dibuat dengan {len(lplpo_items)} item.",
@@ -363,6 +387,8 @@ def lplpo_detail(request, pk):
             "items": items,
             "can_review": can_review,
             "can_approve": can_approve,
+            "can_manage_draft": _is_super_admin(request.user)
+            or request.user.role == User.Role.PUSKESMAS,
         },
     )
 
@@ -441,6 +467,16 @@ def lplpo_edit(request, pk):
                     ],
                 )
 
+            if _is_super_admin(request.user):
+                logger.info(
+                    "super_admin_updated_lplpo_draft",
+                    extra={
+                        "user_id": request.user.pk,
+                        "facility_id": lplpo_obj.facility_id,
+                        "lplpo_id": lplpo_obj.pk,
+                        "status": lplpo_obj.status,
+                    },
+                )
             messages.success(request, f"LPLPO {lplpo_obj.document_number} berhasil disimpan.")
             return redirect("lplpo:lplpo_detail", pk=pk)
 
@@ -512,6 +548,15 @@ def lplpo_submit(request, pk):
         update_fields=["status", "rejection_reason", "submitted_at", "updated_at"]
     )
 
+    if _is_super_admin(request.user):
+        logger.info(
+            "super_admin_submitted_lplpo",
+            extra={
+                "user_id": request.user.pk,
+                "facility_id": lplpo_obj.facility_id,
+                "lplpo_id": lplpo_obj.pk,
+            },
+        )
     messages.success(request, f"LPLPO {lplpo_obj.document_number} berhasil diajukan.")
     return redirect("lplpo:lplpo_detail", pk=pk)
 
@@ -818,7 +863,17 @@ def lplpo_delete(request, pk):
         return redirect("lplpo:lplpo_detail", pk=pk)
 
     doc_number = lplpo_obj.document_number
+    facility_id = lplpo_obj.facility_id
     lplpo_obj.delete()
+    if _is_super_admin(request.user):
+        logger.info(
+            "super_admin_deleted_lplpo",
+            extra={
+                "user_id": request.user.pk,
+                "facility_id": facility_id,
+                "document_number": doc_number,
+            },
+        )
     messages.success(request, f"LPLPO {doc_number} berhasil dihapus.")
 
     if request.user.role == User.Role.PUSKESMAS:

--- a/backend/apps/lplpo/views.py
+++ b/backend/apps/lplpo/views.py
@@ -81,11 +81,11 @@ def _get_submission_month_choices():
     return [(str(month), calendar.month_name[month]) for month in range(1, 13)]
 
 
-def _get_submitted_lplpo_queryset(request):
+def _get_filtered_lplpo_queryset(request, *, submitted_only=True):
     queryset = LPLPO.objects.select_related(
         "facility", "created_by", "reviewed_by", "distribution"
     )
-    if not _is_super_admin(request.user):
+    if submitted_only:
         queryset = queryset.filter(submitted_at__isnull=False)
     queryset = queryset.order_by("-submitted_at", "-tahun", "-bulan", "facility__name")
 
@@ -123,11 +123,14 @@ def _get_submitted_lplpo_queryset(request):
 @login_required
 @perm_required("lplpo.view_lplpo")
 def lplpo_list(request):
-    """Submitted LPLPO queue for Instalasi Farmasi staff."""
+    """LPLPO list for Instalasi Farmasi staff, with super admin access to all statuses."""
     if getattr(request.user, "role", "") == User.Role.PUSKESMAS:
         return redirect("lplpo:lplpo_my_list")
 
-    queryset, filter_context = _get_submitted_lplpo_queryset(request)
+    queryset, filter_context = _get_filtered_lplpo_queryset(
+        request,
+        submitted_only=not _is_super_admin(request.user),
+    )
 
     paginator = Paginator(queryset, 25)
     page = paginator.get_page(request.GET.get("page"))
@@ -823,7 +826,7 @@ def lplpo_print_report(request):
     if getattr(request.user, "role", "") == "PUSKESMAS":
         return redirect("lplpo:lplpo_my_list")
 
-    queryset, filter_context = _get_submitted_lplpo_queryset(request)
+    queryset, filter_context = _get_filtered_lplpo_queryset(request)
 
     return render(
         request,

--- a/backend/templates/lplpo/lplpo_create.html
+++ b/backend/templates/lplpo/lplpo_create.html
@@ -30,7 +30,7 @@
                             {% endif %}
                         </div>
 
-                        {% if not request.user.facility %}
+                        {% if request.user.is_superuser or not request.user.facility %}
                         <div class="mb-3">
                             <label class="form-label fw-semibold">Fasilitas <span class="text-danger">*</span></label>
                             {{ form.facility }}
@@ -49,7 +49,7 @@
                             <button type="submit" class="btn btn-primary" id="submit-create-btn">
                                 <i class="bi bi-plus-lg me-1"></i>Buat LPLPO
                             </button>
-                            <a href="{% url 'lplpo:lplpo_my_list' %}" class="btn btn-outline-secondary">Batal</a>
+                            <a href="{% if request.user.is_superuser %}{% url 'lplpo:lplpo_list' %}{% else %}{% url 'lplpo:lplpo_my_list' %}{% endif %}" class="btn btn-outline-secondary">Batal</a>
                         </div>
                     </form>
                 </div>

--- a/backend/templates/lplpo/lplpo_detail.html
+++ b/backend/templates/lplpo/lplpo_detail.html
@@ -191,7 +191,7 @@
                 <div class="card-header"><h6 class="mb-0">Aksi</h6></div>
                 <div class="card-body d-grid gap-2">
 
-                    {% if lplpo.status == 'DRAFT' and request.user.role == request.user.Role.PUSKESMAS %}
+                    {% if lplpo.status == 'DRAFT' and can_manage_draft %}
                     <a href="{% url 'lplpo:lplpo_edit' lplpo.pk %}" class="btn btn-outline-primary w-100" id="edit-btn">
                         <i class="bi bi-pencil me-1"></i>Isi Data
                     </a>
@@ -210,7 +210,7 @@
                         </button>
                     </form>
 
-                    {% elif lplpo.status == 'REJECTED' and request.user.role == request.user.Role.PUSKESMAS %}
+                    {% elif lplpo.status == 'REJECTED' and can_manage_draft %}
                     <a href="{% url 'lplpo:lplpo_edit' lplpo.pk %}" class="btn btn-outline-primary w-100" id="edit-rejected-btn">
                         <i class="bi bi-pencil me-1"></i>Perbaiki Data
                     </a>

--- a/backend/templates/lplpo/lplpo_list.html
+++ b/backend/templates/lplpo/lplpo_list.html
@@ -9,14 +9,19 @@
     <div class="d-flex justify-content-between align-items-center mb-4">
         <div>
             {% if is_all %}
+            {% if can_manage_all_lplpo %}
+            <h4 class="mb-1">Semua LPLPO</h4>
+            <p class="text-muted mb-0">Super Admin dapat melihat dan mengelola seluruh dokumen LPLPO lintas fasilitas.</p>
+            {% else %}
             <h4 class="mb-1">LPLPO Diajukan Puskesmas</h4>
             <p class="text-muted mb-0">Daftar LPLPO yang sudah diajukan operator Puskesmas untuk diproses Instalasi Farmasi</p>
+            {% endif %}
             {% else %}
             <h4 class="mb-1">LPLPO Saya</h4>
             <p class="text-muted mb-0">Laporan Pemakaian & Lembar Permintaan Obat fasilitas Anda</p>
             {% endif %}
         </div>
-        {% if request.user.role == 'PUSKESMAS' %}
+        {% if request.user.role == 'PUSKESMAS' or can_manage_all_lplpo %}
         <a href="{% url 'lplpo:lplpo_create' %}" class="btn btn-primary" id="create-lplpo-btn">
             <i class="bi bi-plus-lg me-1"></i> Buat LPLPO Baru
         </a>


### PR DESCRIPTION
## Summary
- allow Super Admin to manage LPLPO across facilities, including draft create/edit/submit/delete flows
- fix previous-month `stock_awal` carry-over so non-rejected prior LPLPO can seed the next month
- tighten LPLPO text/year validation and document the behavior changes

## Details
- super admin bypasses Puskesmas-only facility scoping for LPLPO CRUD-related draft actions and sees all LPLPO statuses in the list view
- carry-over no longer requires the previous LPLPO to be `CLOSED`; it now excludes only `REJECTED`
- forms now normalize and sanitize text inputs and reject invalid year values
- regression tests cover super-admin access paths and the carry-over case
- docs updated in `AGENTS.md`, `README.md`, and `SYSTEM_MODEL.md`

## Verification
- `SECURE_SSL_REDIRECT=False; .\scripts\run-django-test.ps1 -Target apps.lplpo`
- Passed: `49` tests

## Follow-up
- Workflow rework planning is tracked in #75 and is not included in this PR.