### PR TITLE
Fix secure test client defaults for distribution and LPLPO tests

### DIFF
--- a/backend/apps/core/tests/mixins.py
+++ b/backend/apps/core/tests/mixins.py
@@ -1,0 +1,45 @@
+from functools import wraps
+
+
+class SecureClientDefaultsMixin:
+    secure_test_host = "localhost"
+
+    def setUp(self):
+        super().setUp()
+        self.client.get = self._secure_client_method(self.client.get)
+        self.client.post = self._secure_client_method(self.client.post)
+
+    def _secure_client_method(self, method):
+        @wraps(method)
+        def wrapped(path, *args, **kwargs):
+            headers = kwargs.pop("headers", {})
+            headers = {"host": self.secure_test_host, **headers}
+            kwargs["secure"] = True
+            kwargs["headers"] = headers
+            return method(path, *args, **kwargs)
+
+        return wrapped
+
+    def secure_get(self, path, data=None, follow=False, **extra):
+        headers = extra.pop("headers", {})
+        headers = {"host": self.secure_test_host, **headers}
+        return self.client.get(
+            path,
+            data=data,
+            follow=follow,
+            secure=True,
+            headers=headers,
+            **extra,
+        )
+
+    def secure_post(self, path, data=None, follow=False, **extra):
+        headers = extra.pop("headers", {})
+        headers = {"host": self.secure_test_host, **headers}
+        return self.client.post(
+            path,
+            data=data,
+            follow=follow,
+            secure=True,
+            headers=headers,
+            **extra,
+        )

--- a/backend/apps/distribution/tests.py
+++ b/backend/apps/distribution/tests.py
@@ -1,6 +1,5 @@
 from datetime import date
 from decimal import Decimal
-from functools import wraps
 from unittest.mock import patch
 
 from django.contrib.staticfiles import finders
@@ -9,6 +8,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from apps.distribution.forms import DistributionForm, DistributionItemForm
+from apps.core.tests.mixins import SecureClientDefaultsMixin
 from apps.distribution.models import Distribution, DistributionItem
 from apps.core.models import SystemSettings
 from apps.items.models import Category, Facility, FundingSource, Item, Location, Unit
@@ -18,10 +18,8 @@ from apps.users.access import ensure_default_module_access
 from apps.users.models import User
 
 
-class DistributionWorkflowTest(TestCase):
+class DistributionWorkflowTest(SecureClientDefaultsMixin, TestCase):
     """Tests for the distribution module workflow transitions and stock posting."""
-
-    secure_test_host = "localhost"
 
     @classmethod
     def setUpTestData(cls):
@@ -83,44 +81,8 @@ class DistributionWorkflowTest(TestCase):
         )
 
     def setUp(self):
-        self.client.get = self._secure_client_method(self.client.get)
-        self.client.post = self._secure_client_method(self.client.post)
+        super().setUp()
         self.client.force_login(self.user)
-
-    def _secure_client_method(self, method):
-        @wraps(method)
-        def wrapped(path, *args, **kwargs):
-            headers = kwargs.pop("headers", {})
-            headers = {"host": self.secure_test_host, **headers}
-            kwargs["secure"] = True
-            kwargs["headers"] = headers
-            return method(path, *args, **kwargs)
-
-        return wrapped
-
-    def secure_get(self, path, data=None, follow=False, **extra):
-        headers = extra.pop("headers", {})
-        headers = {"host": self.secure_test_host, **headers}
-        return self.client.get(
-            path,
-            data=data,
-            follow=follow,
-            secure=True,
-            headers=headers,
-            **extra,
-        )
-
-    def secure_post(self, path, data=None, follow=False, **extra):
-        headers = extra.pop("headers", {})
-        headers = {"host": self.secure_test_host, **headers}
-        return self.client.post(
-            path,
-            data=data,
-            follow=follow,
-            secure=True,
-            headers=headers,
-            **extra,
-        )
 
     def _create_distribution(
         self,

--- a/backend/apps/distribution/tests.py
+++ b/backend/apps/distribution/tests.py
@@ -1,5 +1,6 @@
 from datetime import date
 from decimal import Decimal
+from functools import wraps
 from unittest.mock import patch
 
 from django.contrib.staticfiles import finders
@@ -19,6 +20,8 @@ from apps.users.models import User
 
 class DistributionWorkflowTest(TestCase):
     """Tests for the distribution module workflow transitions and stock posting."""
+
+    secure_test_host = "localhost"
 
     @classmethod
     def setUpTestData(cls):
@@ -80,7 +83,44 @@ class DistributionWorkflowTest(TestCase):
         )
 
     def setUp(self):
+        self.client.get = self._secure_client_method(self.client.get)
+        self.client.post = self._secure_client_method(self.client.post)
         self.client.force_login(self.user)
+
+    def _secure_client_method(self, method):
+        @wraps(method)
+        def wrapped(path, *args, **kwargs):
+            headers = kwargs.pop("headers", {})
+            headers = {"host": self.secure_test_host, **headers}
+            kwargs["secure"] = True
+            kwargs["headers"] = headers
+            return method(path, *args, **kwargs)
+
+        return wrapped
+
+    def secure_get(self, path, data=None, follow=False, **extra):
+        headers = extra.pop("headers", {})
+        headers = {"host": self.secure_test_host, **headers}
+        return self.client.get(
+            path,
+            data=data,
+            follow=follow,
+            secure=True,
+            headers=headers,
+            **extra,
+        )
+
+    def secure_post(self, path, data=None, follow=False, **extra):
+        headers = extra.pop("headers", {})
+        headers = {"host": self.secure_test_host, **headers}
+        return self.client.post(
+            path,
+            data=data,
+            follow=follow,
+            secure=True,
+            headers=headers,
+            **extra,
+        )
 
     def _create_distribution(
         self,

--- a/backend/apps/lplpo/tests.py
+++ b/backend/apps/lplpo/tests.py
@@ -1,7 +1,6 @@
 import importlib
 from datetime import date, datetime
 from decimal import Decimal
-from functools import wraps
 from unittest.mock import Mock, patch
 
 from django.apps import apps as django_apps
@@ -10,6 +9,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
+from apps.core.tests.mixins import SecureClientDefaultsMixin
 from apps.distribution.models import Distribution, DistributionItem
 from apps.items.models import Category, Facility, FundingSource, Item, Location, Unit
 from apps.stock.models import Stock
@@ -23,8 +23,7 @@ from apps.lplpo.models import (
 )
 
 
-class LPLPOTestCase(TestCase):
-	secure_test_host = "localhost"
+class LPLPOTestCase(SecureClientDefaultsMixin, TestCase):
 
 	@classmethod
 	def setUpTestData(cls):
@@ -146,43 +145,7 @@ class LPLPOTestCase(TestCase):
 		lplpo.save(update_fields=["submitted_at", "updated_at"])
 
 	def setUp(self):
-		self.client.get = self._secure_client_method(self.client.get)
-		self.client.post = self._secure_client_method(self.client.post)
-
-	def _secure_client_method(self, method):
-		@wraps(method)
-		def wrapped(path, *args, **kwargs):
-			headers = kwargs.pop("headers", {})
-			headers = {"host": self.secure_test_host, **headers}
-			kwargs["secure"] = True
-			kwargs["headers"] = headers
-			return method(path, *args, **kwargs)
-
-		return wrapped
-
-	def secure_get(self, path, data=None, follow=False, **extra):
-		headers = extra.pop("headers", {})
-		headers = {"host": self.secure_test_host, **headers}
-		return self.client.get(
-			path,
-			data=data,
-			follow=follow,
-			secure=True,
-			headers=headers,
-			**extra,
-		)
-
-	def secure_post(self, path, data=None, follow=False, **extra):
-		headers = extra.pop("headers", {})
-		headers = {"host": self.secure_test_host, **headers}
-		return self.client.post(
-			path,
-			data=data,
-			follow=follow,
-			secure=True,
-			headers=headers,
-			**extra,
-		)
+		super().setUp()
 
 
 class LPLPOWorkflowTests(LPLPOTestCase):

--- a/backend/apps/lplpo/tests.py
+++ b/backend/apps/lplpo/tests.py
@@ -1,6 +1,7 @@
 import importlib
 from datetime import date, datetime
 from decimal import Decimal
+from functools import wraps
 from unittest.mock import Mock, patch
 
 from django.apps import apps as django_apps
@@ -23,6 +24,8 @@ from apps.lplpo.models import (
 
 
 class LPLPOTestCase(TestCase):
+	secure_test_host = "localhost"
+
 	@classmethod
 	def setUpTestData(cls):
 		cls.unit = Unit.objects.create(code="TAB", name="Tablet")
@@ -141,6 +144,45 @@ class LPLPOTestCase(TestCase):
 	def set_submitted_at(self, lplpo, year, month, day):
 		lplpo.submitted_at = timezone.make_aware(datetime(year, month, day))
 		lplpo.save(update_fields=["submitted_at", "updated_at"])
+
+	def setUp(self):
+		self.client.get = self._secure_client_method(self.client.get)
+		self.client.post = self._secure_client_method(self.client.post)
+
+	def _secure_client_method(self, method):
+		@wraps(method)
+		def wrapped(path, *args, **kwargs):
+			headers = kwargs.pop("headers", {})
+			headers = {"host": self.secure_test_host, **headers}
+			kwargs["secure"] = True
+			kwargs["headers"] = headers
+			return method(path, *args, **kwargs)
+
+		return wrapped
+
+	def secure_get(self, path, data=None, follow=False, **extra):
+		headers = extra.pop("headers", {})
+		headers = {"host": self.secure_test_host, **headers}
+		return self.client.get(
+			path,
+			data=data,
+			follow=follow,
+			secure=True,
+			headers=headers,
+			**extra,
+		)
+
+	def secure_post(self, path, data=None, follow=False, **extra):
+		headers = extra.pop("headers", {})
+		headers = {"host": self.secure_test_host, **headers}
+		return self.client.post(
+			path,
+			data=data,
+			follow=follow,
+			secure=True,
+			headers=headers,
+			**extra,
+		)
 
 
 class LPLPOWorkflowTests(LPLPOTestCase):


### PR DESCRIPTION
## Summary
- force the distribution and LPLPO test clients to send HTTPS requests with an allowed host by default
- keep redirect follow-up requests under HTTPS so `assertRedirects()` works with production-like security settings
- preserve existing suite behavior while hardening the shared test harness

Closes #85

## Verification
```bash
python manage.py test apps.distribution.tests.DistributionWorkflowTest apps.lplpo.tests
```