### PR TITLE
feat(report): implement detailed reporting endpoints and filters for distribution types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ If documentation conflicts with code, code is authoritative until docs are corre
 - `stock_opname`: physical counting workflow
 - `puskesmas`: ad-hoc requests from Puskesmas
 - `lplpo`: monthly reporting and stock requests from Puskesmas
-- `reports`: report index with rekap, hibah receiving, procurement, expiry, outbound reporting views, and document numbering history for LPLPO/Special Request distributions
+- `reports`: report index with rekap, hibah receiving, procurement, expiry, outbound reporting views, and document numbering history for LPLPO/Special Request distributions. The combined outbound report remains on `/reports/pengeluaran/`, while the distribution module owns dedicated route-based report variants at `/distribution/report/`, `/distribution/report/special-requests/`, `/distribution/report/allocation/`, and `/distribution/report/lplpo/`.
 
 ## Permissions Model
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Solusi ini membantu proses inventaris berjalan lebih konsisten melalui alur doku
 - `users`: manajemen pengguna dan pengaturan cakupan akses modul.
 
 - `core`: dashboard, middleware akses panel admin, pengaturan sistem (label platform login, logo, header dokumen, nama fasilitas, serta template penomoran dokumen distribusi) secara dinamis, placeholder riwayat administrasi terpisah untuk penerimaan serta pengeluaran, dan handler error terpusat untuk `400/403/404/500` plus halaman maintenance `503`.
-- `reports`: halaman ringkasan laporan dengan keluaran `rekap`, `penerimaan hibah`, `pengadaan`, `kadaluarsa`, dan `pengeluaran`.
+- `reports`: halaman ringkasan laporan dengan keluaran `rekap`, `penerimaan hibah`, `pengadaan`, `kadaluarsa`, dan `pengeluaran`; laporan `pengeluaran` tetap tersedia sebagai ringkasan gabungan di `/reports/pengeluaran/`, sedangkan riwayat distribusi menyediakan endpoint khusus di `/distribution/report/`, `/distribution/report/special-requests/`, `/distribution/report/allocation/`, dan `/distribution/report/lplpo/`.
 
 ## Ringkasan Workflow
 

--- a/SYSTEM_MODEL.md
+++ b/SYSTEM_MODEL.md
@@ -50,7 +50,7 @@ Module highlights:
 - Receiving regular: `/receiving/`, `/receiving/create/`, `/receiving/<pk>/`
 - Receiving plan: `/receiving/plans/*`
 - Receiving quick-create APIs: `/receiving/api/quick-create-supplier/`, `/receiving/api/quick-create-funding-source/`, `/receiving/api/quick-create-receiving-type/`
-- Distribution history: `/distribution/`, `/distribution/create/`, `/distribution/<pk>/`, `/distribution/<pk>/edit/`, `/distribution/<pk>/delete/`, `/distribution/<pk>/step-back/`, `/distribution/<pk>/reset-to-draft/`, `/distribution/<pk>/submit/`, `/distribution/<pk>/verify/`, `/distribution/<pk>/prepare/`, `/distribution/<pk>/distribute/`, `/distribution/<pk>/reject/`
+- Distribution history: `/distribution/`, `/distribution/report/`, `/distribution/report/special-requests/`, `/distribution/report/allocation/`, `/distribution/report/lplpo/`, `/distribution/create/`, `/distribution/<pk>/`, `/distribution/<pk>/edit/`, `/distribution/<pk>/delete/`, `/distribution/<pk>/step-back/`, `/distribution/<pk>/reset-to-draft/`, `/distribution/<pk>/submit/`, `/distribution/<pk>/verify/`, `/distribution/<pk>/prepare/`, `/distribution/<pk>/distribute/`, `/distribution/<pk>/reject/`
 - Special requests: `/distribution/special-requests/`, `/distribution/special-requests/create/`
 - Expiry alerts: `/expired/alerts/`
 - Reports: `/reports/`, `/reports/riwayat-penomoran/`, `/reports/rekap/`, `/reports/penerimaan-hibah/`, `/reports/pengadaan/`, `/reports/kadaluarsa/`, `/reports/pengeluaran/`
@@ -292,7 +292,7 @@ This section reflects model code in `backend/apps/*/models.py`.
 
 ### 4.11 Reports
 
-- `reports`: Contains views, templates, and services for inventory, expiry, receiving, outbound, and document-numbering-history reporting with Excel export capabilities. No bespoke database models, aggregates data from other apps.
+- `reports`: Contains views, templates, and services for inventory, expiry, receiving, outbound, and document-numbering-history reporting with Excel export capabilities. The combined outbound recap remains available on `/reports/pengeluaran/`, while the distribution module exposes route-based filtered variants for `SPECIAL_REQUEST`, `ALLOCATION`, and `LPLPO` under `/distribution/report/*`. No bespoke database models, aggregates data from other apps.
 
 ### 4.12 Puskesmas
 

--- a/backend/apps/distribution/tests.py
+++ b/backend/apps/distribution/tests.py
@@ -1321,6 +1321,23 @@ class DistributionWorkflowTest(SecureClientDefaultsMixin, TestCase):
         self.assertContains(response, reverse("distribution:distribution_report_allocation"))
         self.assertContains(response, reverse("distribution:distribution_report_lplpo"))
 
+    def test_distribution_report_endpoints_require_reports_permission(self):
+        restricted_user = User.objects.create_user(
+            username="puskesmas_no_reports_view",
+            role=User.Role.PUSKESMAS,
+        )
+        self.client.force_login(restricted_user)
+
+        for url_name in (
+            "distribution:distribution_report",
+            "distribution:distribution_report_special_request",
+            "distribution:distribution_report_allocation",
+            "distribution:distribution_report_lplpo",
+        ):
+            with self.subTest(url_name=url_name):
+                response = self.client.get(reverse(url_name))
+                self.assertEqual(response.status_code, 403)
+
     def test_distribution_list_requires_view_permission(self):
         restricted_user = User.objects.create_user(
             username="puskesmas_no_distribution_view",

--- a/backend/apps/distribution/tests.py
+++ b/backend/apps/distribution/tests.py
@@ -16,7 +16,7 @@ from apps.items.models import Category, Facility, FundingSource, Item, Location,
 from apps.lplpo.models import LPLPO
 from apps.stock.models import Stock, Transaction
 from apps.users.access import ensure_default_module_access
-from apps.users.models import User
+from apps.users.models import ModuleAccess, User
 
 
 class DistributionWorkflowTest(SecureClientDefaultsMixin, TestCase):
@@ -1349,6 +1349,27 @@ class DistributionWorkflowTest(SecureClientDefaultsMixin, TestCase):
         response = self.client.get(reverse("distribution:distribution_list"))
 
         self.assertEqual(response.status_code, 403)
+
+    def test_distribution_list_hides_report_button_without_reports_permission(self):
+        restricted_user = User.objects.create_user(
+            username="gudang_without_reports_access",
+            password="secret12345",
+            role=User.Role.GUDANG,
+        )
+        ensure_default_module_access(restricted_user, overwrite=True)
+        ModuleAccess.objects.filter(
+            user=restricted_user,
+            module=ModuleAccess.Module.REPORTS,
+        ).update(scope=ModuleAccess.Scope.NONE)
+        self.client.force_login(restricted_user)
+
+        response = self.client.get(reverse("distribution:distribution_list"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            reverse("distribution:distribution_report"),
+        )
 
     def test_special_request_list_filters_special_request_records(self):
         special_request = self._create_distribution(

--- a/backend/apps/distribution/tests.py
+++ b/backend/apps/distribution/tests.py
@@ -1278,8 +1278,48 @@ class DistributionWorkflowTest(SecureClientDefaultsMixin, TestCase):
         response = self.client.get(reverse("distribution:distribution_list"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, reverse("reports:pengeluaran"))
+        self.assertContains(response, reverse("distribution:distribution_report"))
         self.assertNotContains(response, "Buat Distribusi")
+
+    def test_distribution_report_endpoint_renders_outbound_report(self):
+        response = self.client.get(reverse("distribution:distribution_report"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Laporan Pengeluaran / Distribusi")
+        self.assertContains(response, "Semua Distribusi")
+
+    def test_distribution_report_special_request_endpoint_filters_to_special_request(self):
+        special_request = self._create_distribution(
+            status=Distribution.Status.DISTRIBUTED,
+            distribution_type=Distribution.DistributionType.SPECIAL_REQUEST,
+            with_items=True,
+        )
+        lplpo = self._create_distribution(
+            status=Distribution.Status.DISTRIBUTED,
+            distribution_type=Distribution.DistributionType.LPLPO,
+            with_items=True,
+        )
+
+        response = self.client.get(
+            reverse("distribution:distribution_report_special_request"),
+            {
+                "start_date": "2026-03-01",
+                "end_date": "2026-03-31",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, special_request.document_number)
+        self.assertNotContains(response, lplpo.document_number)
+
+    def test_distribution_report_tabs_use_dedicated_distribution_urls(self):
+        response = self.client.get(reverse("distribution:distribution_report"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, reverse("distribution:distribution_report"))
+        self.assertContains(response, reverse("distribution:distribution_report_special_request"))
+        self.assertContains(response, reverse("distribution:distribution_report_allocation"))
+        self.assertContains(response, reverse("distribution:distribution_report_lplpo"))
 
     def test_distribution_list_requires_view_permission(self):
         restricted_user = User.objects.create_user(

--- a/backend/apps/distribution/urls.py
+++ b/backend/apps/distribution/urls.py
@@ -5,6 +5,22 @@ app_name = "distribution"
 
 urlpatterns = [
     path("", views.distribution_list, name="distribution_list"),
+    path("report/", views.distribution_report, name="distribution_report"),
+    path(
+        "report/special-requests/",
+        views.distribution_report_special_request,
+        name="distribution_report_special_request",
+    ),
+    path(
+        "report/allocation/",
+        views.distribution_report_allocation,
+        name="distribution_report_allocation",
+    ),
+    path(
+        "report/lplpo/",
+        views.distribution_report_lplpo,
+        name="distribution_report_lplpo",
+    ),
     path(
         "special-requests/",
         views.special_request_list,

--- a/backend/apps/distribution/views.py
+++ b/backend/apps/distribution/views.py
@@ -36,6 +36,14 @@ from .services import (
 logger = logging.getLogger(__name__)
 
 
+_DISTRIBUTION_REPORT_TAB_URL_NAMES = {
+    "": "distribution:distribution_report",
+    Distribution.DistributionType.SPECIAL_REQUEST: "distribution:distribution_report_special_request",
+    Distribution.DistributionType.ALLOCATION: "distribution:distribution_report_allocation",
+    Distribution.DistributionType.LPLPO: "distribution:distribution_report_lplpo",
+}
+
+
 def _redirect_distribution_detail(pk):
     return redirect("distribution:distribution_detail", pk=pk)
 
@@ -207,12 +215,7 @@ def distribution_report(request):
     return render_pengeluaran_report(
         request,
         base_report_url_name="distribution:distribution_report",
-        tab_url_names={
-            "": "distribution:distribution_report",
-            Distribution.DistributionType.SPECIAL_REQUEST: "distribution:distribution_report_special_request",
-            Distribution.DistributionType.ALLOCATION: "distribution:distribution_report_allocation",
-            Distribution.DistributionType.LPLPO: "distribution:distribution_report_lplpo",
-        },
+        tab_url_names=_DISTRIBUTION_REPORT_TAB_URL_NAMES,
     )
 
 
@@ -225,12 +228,7 @@ def distribution_report_special_request(request):
         request,
         forced_distribution_type=Distribution.DistributionType.SPECIAL_REQUEST,
         base_report_url_name="distribution:distribution_report",
-        tab_url_names={
-            "": "distribution:distribution_report",
-            Distribution.DistributionType.SPECIAL_REQUEST: "distribution:distribution_report_special_request",
-            Distribution.DistributionType.ALLOCATION: "distribution:distribution_report_allocation",
-            Distribution.DistributionType.LPLPO: "distribution:distribution_report_lplpo",
-        },
+        tab_url_names=_DISTRIBUTION_REPORT_TAB_URL_NAMES,
     )
 
 
@@ -243,12 +241,7 @@ def distribution_report_allocation(request):
         request,
         forced_distribution_type=Distribution.DistributionType.ALLOCATION,
         base_report_url_name="distribution:distribution_report",
-        tab_url_names={
-            "": "distribution:distribution_report",
-            Distribution.DistributionType.SPECIAL_REQUEST: "distribution:distribution_report_special_request",
-            Distribution.DistributionType.ALLOCATION: "distribution:distribution_report_allocation",
-            Distribution.DistributionType.LPLPO: "distribution:distribution_report_lplpo",
-        },
+        tab_url_names=_DISTRIBUTION_REPORT_TAB_URL_NAMES,
     )
 
 
@@ -261,12 +254,7 @@ def distribution_report_lplpo(request):
         request,
         forced_distribution_type=Distribution.DistributionType.LPLPO,
         base_report_url_name="distribution:distribution_report",
-        tab_url_names={
-            "": "distribution:distribution_report",
-            Distribution.DistributionType.SPECIAL_REQUEST: "distribution:distribution_report_special_request",
-            Distribution.DistributionType.ALLOCATION: "distribution:distribution_report_allocation",
-            Distribution.DistributionType.LPLPO: "distribution:distribution_report_lplpo",
-        },
+        tab_url_names=_DISTRIBUTION_REPORT_TAB_URL_NAMES,
     )
 
 

--- a/backend/apps/distribution/views.py
+++ b/backend/apps/distribution/views.py
@@ -12,7 +12,11 @@ from django.shortcuts import get_object_or_404, redirect, render
 from apps.core.decorators import module_scope_required, perm_required
 from apps.lplpo.forms import RejectLPLPOForm
 from apps.lplpo.models import LPLPO
-from apps.users.access import has_module_scope
+from apps.reports.views import (
+    _PENGELUARAN_REPORT_TAB_URL_NAMES,
+    render_pengeluaran_report,
+)
+from apps.users.access import has_module_permission, has_module_scope
 from apps.users.models import ModuleAccess, User
 
 from .forms import (
@@ -37,6 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 _DISTRIBUTION_REPORT_TAB_URL_NAMES = {
+    **_PENGELUARAN_REPORT_TAB_URL_NAMES,
     "": "distribution:distribution_report",
     Distribution.DistributionType.SPECIAL_REQUEST: "distribution:distribution_report_special_request",
     Distribution.DistributionType.ALLOCATION: "distribution:distribution_report_allocation",
@@ -82,6 +87,12 @@ def _can_return_generated_lplpo_to_puskesmas(user, distribution):
             ModuleAccess.Module.LPLPO,
             ModuleAccess.Scope.APPROVE,
         )
+    )
+
+
+def _can_view_reports(user):
+    return user.is_superuser or user.has_perm("reports.view_reports") or has_module_permission(
+        user, "reports.view_reports"
     )
 
 
@@ -192,6 +203,7 @@ def distribution_list(request):
         .exclude(distribution_type__in=["BORROW_RS", "SWAP_RS"])
         .order_by("-request_date")
     )
+    can_view_reports = _can_view_reports(request.user)
 
     return _render_distribution_list(
         request,
@@ -202,16 +214,14 @@ def distribution_list(request):
         empty_state_text="Belum ada riwayat pengeluaran",
         active_pengeluaran_submenu="distribution_history",
         show_type_filter=True,
-        report_url_name="distribution:distribution_report",
-        report_button_label="Laporan Pengeluaran",
+        report_url_name="distribution:distribution_report" if can_view_reports else None,
+        report_button_label="Laporan Pengeluaran" if can_view_reports else None,
     )
 
 
 @login_required
 @perm_required("reports.view_reports")
 def distribution_report(request):
-    from apps.reports.views import render_pengeluaran_report
-
     return render_pengeluaran_report(
         request,
         base_report_url_name="distribution:distribution_report",
@@ -222,8 +232,6 @@ def distribution_report(request):
 @login_required
 @perm_required("reports.view_reports")
 def distribution_report_special_request(request):
-    from apps.reports.views import render_pengeluaran_report
-
     return render_pengeluaran_report(
         request,
         forced_distribution_type=Distribution.DistributionType.SPECIAL_REQUEST,
@@ -235,8 +243,6 @@ def distribution_report_special_request(request):
 @login_required
 @perm_required("reports.view_reports")
 def distribution_report_allocation(request):
-    from apps.reports.views import render_pengeluaran_report
-
     return render_pengeluaran_report(
         request,
         forced_distribution_type=Distribution.DistributionType.ALLOCATION,
@@ -248,8 +254,6 @@ def distribution_report_allocation(request):
 @login_required
 @perm_required("reports.view_reports")
 def distribution_report_lplpo(request):
-    from apps.reports.views import render_pengeluaran_report
-
     return render_pengeluaran_report(
         request,
         forced_distribution_type=Distribution.DistributionType.LPLPO,

--- a/backend/apps/distribution/views.py
+++ b/backend/apps/distribution/views.py
@@ -194,8 +194,79 @@ def distribution_list(request):
         empty_state_text="Belum ada riwayat pengeluaran",
         active_pengeluaran_submenu="distribution_history",
         show_type_filter=True,
-        report_url_name="reports:pengeluaran",
+        report_url_name="distribution:distribution_report",
         report_button_label="Laporan Pengeluaran",
+    )
+
+
+@login_required
+@perm_required("reports.view_reports")
+def distribution_report(request):
+    from apps.reports.views import render_pengeluaran_report
+
+    return render_pengeluaran_report(
+        request,
+        base_report_url_name="distribution:distribution_report",
+        tab_url_names={
+            "": "distribution:distribution_report",
+            Distribution.DistributionType.SPECIAL_REQUEST: "distribution:distribution_report_special_request",
+            Distribution.DistributionType.ALLOCATION: "distribution:distribution_report_allocation",
+            Distribution.DistributionType.LPLPO: "distribution:distribution_report_lplpo",
+        },
+    )
+
+
+@login_required
+@perm_required("reports.view_reports")
+def distribution_report_special_request(request):
+    from apps.reports.views import render_pengeluaran_report
+
+    return render_pengeluaran_report(
+        request,
+        forced_distribution_type=Distribution.DistributionType.SPECIAL_REQUEST,
+        base_report_url_name="distribution:distribution_report",
+        tab_url_names={
+            "": "distribution:distribution_report",
+            Distribution.DistributionType.SPECIAL_REQUEST: "distribution:distribution_report_special_request",
+            Distribution.DistributionType.ALLOCATION: "distribution:distribution_report_allocation",
+            Distribution.DistributionType.LPLPO: "distribution:distribution_report_lplpo",
+        },
+    )
+
+
+@login_required
+@perm_required("reports.view_reports")
+def distribution_report_allocation(request):
+    from apps.reports.views import render_pengeluaran_report
+
+    return render_pengeluaran_report(
+        request,
+        forced_distribution_type=Distribution.DistributionType.ALLOCATION,
+        base_report_url_name="distribution:distribution_report",
+        tab_url_names={
+            "": "distribution:distribution_report",
+            Distribution.DistributionType.SPECIAL_REQUEST: "distribution:distribution_report_special_request",
+            Distribution.DistributionType.ALLOCATION: "distribution:distribution_report_allocation",
+            Distribution.DistributionType.LPLPO: "distribution:distribution_report_lplpo",
+        },
+    )
+
+
+@login_required
+@perm_required("reports.view_reports")
+def distribution_report_lplpo(request):
+    from apps.reports.views import render_pengeluaran_report
+
+    return render_pengeluaran_report(
+        request,
+        forced_distribution_type=Distribution.DistributionType.LPLPO,
+        base_report_url_name="distribution:distribution_report",
+        tab_url_names={
+            "": "distribution:distribution_report",
+            Distribution.DistributionType.SPECIAL_REQUEST: "distribution:distribution_report_special_request",
+            Distribution.DistributionType.ALLOCATION: "distribution:distribution_report_allocation",
+            Distribution.DistributionType.LPLPO: "distribution:distribution_report_lplpo",
+        },
     )
 
 

--- a/backend/apps/reports/exports.py
+++ b/backend/apps/reports/exports.py
@@ -446,7 +446,13 @@ def export_kadaluarsa_excel(report_data, start_date, end_date):
     )
 
 
-def export_pengeluaran_excel(report_data, start_date, end_date, facility_name='Semua Fasilitas'):
+def export_pengeluaran_excel(
+    report_data,
+    start_date,
+    end_date,
+    facility_name='Semua Fasilitas',
+    distribution_type_label='Semua Distribusi',
+):
     """Export the Pengeluaran (distribution) report to Excel."""
     wb = Workbook()
     ws = wb.active
@@ -468,7 +474,10 @@ def export_pengeluaran_excel(report_data, start_date, end_date, facility_name='S
 
     ws.merge_cells(f"A2:{last_col}2")
     period_cell = ws.cell(row=2, column=1,
-                          value=f"Periode: {start_date} s/d {end_date} | Fasilitas: {facility_name}")
+                          value=(
+                              f"Periode: {start_date} s/d {end_date} | "
+                              f"Fasilitas: {facility_name} | Jenis Distribusi: {distribution_type_label}"
+                          ))
     period_cell.font = Font(bold=True, size=11)
     period_cell.alignment = Alignment(horizontal="center")
 
@@ -523,5 +532,6 @@ def export_pengeluaran_excel(report_data, start_date, end_date, facility_name='S
     val_cell.number_format = IDR_FORMAT
     val_cell.alignment = Alignment(horizontal="right")
 
-    filename = f"Laporan_Pengeluaran_{start_date}_{end_date}.xlsx"
+    safe_distribution_type = distribution_type_label.replace(' ', '_').replace('/', '_')
+    filename = f"Laporan_Pengeluaran_{safe_distribution_type}_{start_date}_{end_date}.xlsx"
     return _make_response(wb, filename)

--- a/backend/apps/reports/forms.py
+++ b/backend/apps/reports/forms.py
@@ -35,6 +35,17 @@ class InventoryReportFilterForm(forms.Form):
 
 
 class PengeluaranReportFilterForm(InventoryReportFilterForm):
+    distribution_type = forms.ChoiceField(
+        label='Jenis Distribusi',
+        required=False,
+        choices=[
+            ('', 'Semua Distribusi'),
+            (Distribution.DistributionType.SPECIAL_REQUEST, 'Permintaan Khusus'),
+            (Distribution.DistributionType.ALLOCATION, 'Alokasi'),
+            (Distribution.DistributionType.LPLPO, 'LPLPO'),
+        ],
+        widget=forms.HiddenInput(),
+    )
     facility = forms.ModelChoiceField(
         label='Fasilitas',
         queryset=None,
@@ -47,6 +58,12 @@ class PengeluaranReportFilterForm(InventoryReportFilterForm):
         super().__init__(*args, **kwargs)
         from apps.items.models import Facility
         self.fields['facility'].queryset = Facility.objects.filter(is_active=True).order_by('name')
+
+    @classmethod
+    def get_default_initial(cls):
+        initial = super().get_default_initial()
+        initial['distribution_type'] = ''
+        return initial
 
 
 class NumberingHistoryFilterForm(forms.Form):

--- a/backend/apps/reports/tests.py
+++ b/backend/apps/reports/tests.py
@@ -105,3 +105,183 @@ class NumberingHistoryReportTests(TestCase):
 			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 		)
 		self.assertIn('Riwayat_Penomoran_2026.xlsx', response['Content-Disposition'])
+
+
+class PengeluaranReportTests(TestCase):
+	@classmethod
+	def setUpTestData(cls):
+		cls.user = User.objects.create_superuser(
+			username="pengeluaran-admin",
+			password="secret12345",
+		)
+		cls.unit = Unit.objects.create(code="BOT", name="Botol")
+		cls.category = Category.objects.create(
+			code="OUT-CAT", name="Outbound Category", sort_order=1
+		)
+		cls.item = Item.objects.create(
+			nama_barang="Amoxicillin Syrup",
+			satuan=cls.unit,
+			kategori=cls.category,
+		)
+		cls.location = Location.objects.create(code="OUT-LOC", name="Gudang Pengeluaran")
+		cls.funding_source = FundingSource.objects.create(code="DAU", name="DAU")
+		cls.facility = Facility.objects.create(code="PKM-OUT", name="Puskesmas Pengeluaran")
+		cls.other_facility = Facility.objects.create(code="PKM-ALT", name="Puskesmas Alternatif")
+		cls.stock = Stock.objects.create(
+			item=cls.item,
+			location=cls.location,
+			batch_lot="OUT-01",
+			expiry_date="2027-10-31",
+			quantity=50,
+			reserved=0,
+			unit_price=2500,
+			sumber_dana=cls.funding_source,
+		)
+
+	def setUp(self):
+		self.client.force_login(self.user)
+
+	def _create_distribution(self, distribution_type, facility=None, document_number=None):
+		dist = Distribution.objects.create(
+			distribution_type=distribution_type,
+			document_number=document_number or "",
+			request_date="2026-04-15",
+			facility=facility or self.facility,
+			status=Distribution.Status.DISTRIBUTED,
+			created_by=self.user,
+			notes="Pengeluaran terverifikasi",
+		)
+		dist.items.create(
+			item=self.item,
+			quantity_requested=7,
+			quantity_approved=5,
+			stock=self.stock,
+		)
+		return dist
+
+	def test_pengeluaran_report_filters_by_distribution_type(self):
+		allocation_dist = self._create_distribution(
+			Distribution.DistributionType.ALLOCATION,
+			document_number="ALLOC-REP-001",
+		)
+		self._create_distribution(
+			Distribution.DistributionType.LPLPO,
+			document_number="LPLPO-REP-001",
+		)
+
+		response = self.client.get(
+			reverse('reports:pengeluaran'),
+			{
+				'start_date': '2026-04-01',
+				'end_date': '2026-04-30',
+				'distribution_type': Distribution.DistributionType.ALLOCATION,
+			},
+		)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, allocation_dist.document_number)
+		self.assertNotContains(response, 'LPLPO-REP-001')
+
+	def test_pengeluaran_report_combined_view_remains_available(self):
+		allocation_dist = self._create_distribution(
+			Distribution.DistributionType.ALLOCATION,
+			document_number="ALLOC-REP-ALL",
+		)
+		lplpo_dist = self._create_distribution(
+			Distribution.DistributionType.LPLPO,
+			document_number="LPLPO-REP-ALL",
+		)
+
+		response = self.client.get(
+			reverse('reports:pengeluaran'),
+			{
+				'start_date': '2026-04-01',
+				'end_date': '2026-04-30',
+			},
+		)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, allocation_dist.document_number)
+		self.assertContains(response, lplpo_dist.document_number)
+		self.assertContains(response, 'Semua Distribusi')
+		self.assertContains(response, 'Permintaan Khusus')
+		self.assertContains(response, 'Alokasi')
+		self.assertContains(response, 'LPLPO')
+
+	def test_pengeluaran_report_combines_facility_and_distribution_type_filters(self):
+		matching_dist = self._create_distribution(
+			Distribution.DistributionType.SPECIAL_REQUEST,
+			facility=self.facility,
+			document_number="SPEC-REP-001",
+		)
+		self._create_distribution(
+			Distribution.DistributionType.SPECIAL_REQUEST,
+			facility=self.other_facility,
+			document_number="SPEC-REP-ALT",
+		)
+		self._create_distribution(
+			Distribution.DistributionType.ALLOCATION,
+			facility=self.facility,
+			document_number="ALLOC-REP-FAC",
+		)
+
+		response = self.client.get(
+			reverse('reports:pengeluaran'),
+			{
+				'start_date': '2026-04-01',
+				'end_date': '2026-04-30',
+				'facility': self.facility.pk,
+				'distribution_type': Distribution.DistributionType.SPECIAL_REQUEST,
+			},
+		)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, matching_dist.document_number)
+		self.assertNotContains(response, 'SPEC-REP-ALT')
+		self.assertNotContains(response, 'ALLOC-REP-FAC')
+
+	def test_pengeluaran_report_invalid_distribution_type_keeps_report_empty(self):
+		self._create_distribution(
+			Distribution.DistributionType.ALLOCATION,
+			document_number="ALLOC-REP-INVALID",
+		)
+
+		response = self.client.get(
+			reverse('reports:pengeluaran'),
+			{
+				'start_date': '2026-04-01',
+				'end_date': '2026-04-30',
+				'distribution_type': 'NOT_A_REAL_TYPE',
+			},
+		)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertFalse(response.context['form'].is_valid())
+		self.assertEqual(response.context['report_data'], [])
+		self.assertNotContains(response, 'ALLOC-REP-INVALID')
+
+	def test_pengeluaran_report_excel_export_uses_active_tab_label(self):
+		self._create_distribution(
+			Distribution.DistributionType.ALLOCATION,
+			document_number="ALLOC-REP-EXPORT",
+		)
+
+		response = self.client.get(
+			reverse('reports:pengeluaran'),
+			{
+				'start_date': '2026-04-01',
+				'end_date': '2026-04-30',
+				'distribution_type': Distribution.DistributionType.ALLOCATION,
+				'format': 'excel',
+			},
+		)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(
+			response['Content-Type'],
+			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+		)
+		self.assertIn(
+			'Laporan_Pengeluaran_Alokasi_2026-04-01_2026-04-30.xlsx',
+			response['Content-Disposition'],
+		)

--- a/backend/apps/reports/tests.py
+++ b/backend/apps/reports/tests.py
@@ -285,3 +285,24 @@ class PengeluaranReportTests(TestCase):
 			'Laporan_Pengeluaran_Alokasi_2026-04-01_2026-04-30.xlsx',
 			response['Content-Disposition'],
 		)
+
+	def test_pengeluaran_report_tabs_include_distribution_type_query(self):
+		response = self.client.get(
+			reverse('reports:pengeluaran'),
+			{
+				'start_date': '2026-04-01',
+				'end_date': '2026-04-30',
+			},
+		)
+
+		self.assertEqual(response.status_code, 200)
+		tabs = response.context['tabs']
+		self.assertTrue(any(tab['value'] == '' for tab in tabs))
+		self.assertTrue(any(tab['value'] == Distribution.DistributionType.ALLOCATION for tab in tabs))
+
+		allocation_tab = next(
+			tab for tab in tabs if tab['value'] == Distribution.DistributionType.ALLOCATION
+		)
+		self.assertIn('distribution_type=ALLOCATION', allocation_tab['url'])
+		self.assertIn('start_date=2026-04-01', allocation_tab['url'])
+		self.assertIn('end_date=2026-04-30', allocation_tab['url'])

--- a/backend/apps/reports/views.py
+++ b/backend/apps/reports/views.py
@@ -15,6 +15,15 @@ from .exports import (
 from apps.stock.models import Transaction, Stock
 from apps.distribution.models import Distribution
 
+
+_PENGELUARAN_REPORT_TAB_URL_NAMES = {
+    '': 'reports:pengeluaran',
+    Distribution.DistributionType.SPECIAL_REQUEST: 'reports:pengeluaran',
+    Distribution.DistributionType.ALLOCATION: 'reports:pengeluaran',
+    Distribution.DistributionType.LPLPO: 'reports:pengeluaran',
+}
+
+
 @login_required
 @perm_required('reports.view_reports')
 def reports_index(request):
@@ -648,12 +657,7 @@ def render_pengeluaran_report(
             )
 
     if tab_url_names is None:
-        tab_url_names = {
-            '': 'reports:pengeluaran',
-            'SPECIAL_REQUEST': 'reports:pengeluaran',
-            'ALLOCATION': 'reports:pengeluaran',
-            'LPLPO': 'reports:pengeluaran',
-        }
+        tab_url_names = _PENGELUARAN_REPORT_TAB_URL_NAMES
 
     tab_choices = PengeluaranReportFilterForm.base_fields['distribution_type'].choices
     tab_base_params = effective_querydict.copy()

--- a/backend/apps/reports/views.py
+++ b/backend/apps/reports/views.py
@@ -591,12 +591,14 @@ def render_pengeluaran_report(
     selected_distribution_type_label = dict(
         PengeluaranReportFilterForm.base_fields['distribution_type'].choices
     ).get(active_distribution_type, 'Semua Distribusi')
+    selected_facility_name = 'Semua Fasilitas'
 
     if form.is_valid():
         start_date = form.cleaned_data.get('start_date')
         end_date = form.cleaned_data.get('end_date')
         distribution_type = forced_distribution_type or form.cleaned_data.get('distribution_type')
         facility = form.cleaned_data.get('facility')
+        selected_facility_name = facility.name if facility else 'Semua Fasilitas'
         active_distribution_type = distribution_type or ''
         selected_distribution_type_label = dict(form.fields['distribution_type'].choices).get(
             active_distribution_type,
@@ -637,7 +639,6 @@ def render_pengeluaran_report(
             })
 
         if request.GET.get('format') == 'excel' and report_data:
-            selected_facility_name = facility.name if facility else 'Semua Fasilitas'
             return export_pengeluaran_excel(
                 report_data,
                 start_date,
@@ -661,6 +662,8 @@ def render_pengeluaran_report(
     tabs = []
     for value, label in tab_choices:
         tab_params = tab_base_params.copy()
+        if value:
+            tab_params['distribution_type'] = value
         tab_url = reverse(tab_url_names.get(value, base_report_url_name))
         encoded_params = tab_params.urlencode()
         if encoded_params:
@@ -685,6 +688,7 @@ def render_pengeluaran_report(
         'tabs': tabs,
         'active_distribution_type': active_distribution_type,
         'selected_distribution_type_label': selected_distribution_type_label,
+        'selected_facility_name': selected_facility_name,
         'base_report_url_name': base_report_url_name,
     }
     return render(request, 'reports/pengeluaran.html', context)

--- a/backend/apps/reports/views.py
+++ b/backend/apps/reports/views.py
@@ -563,17 +563,45 @@ def reports_kadaluarsa(request):
 @login_required
 @perm_required('reports.view_reports')
 def reports_pengeluaran(request):
+    return render_pengeluaran_report(request)
+
+
+def render_pengeluaran_report(
+    request,
+    *,
+    forced_distribution_type='',
+    base_report_url_name='reports:pengeluaran',
+    tab_url_names=None,
+):
     from apps.distribution.models import DistributionItem
     from .forms import PengeluaranReportFilterForm
     from .exports import export_pengeluaran_excel
 
-    form = PengeluaranReportFilterForm(request.GET or PengeluaranReportFilterForm.get_default_initial())
+    initial_data = PengeluaranReportFilterForm.get_default_initial()
+    effective_querydict = request.GET.copy()
+    for key, value in initial_data.items():
+        if not effective_querydict.get(key):
+            effective_querydict[key] = value
+    if forced_distribution_type:
+        effective_querydict['distribution_type'] = forced_distribution_type
+
+    form = PengeluaranReportFilterForm(effective_querydict)
     report_data = []
+    active_distribution_type = forced_distribution_type or effective_querydict.get('distribution_type', '') or ''
+    selected_distribution_type_label = dict(
+        PengeluaranReportFilterForm.base_fields['distribution_type'].choices
+    ).get(active_distribution_type, 'Semua Distribusi')
 
     if form.is_valid():
         start_date = form.cleaned_data.get('start_date')
         end_date = form.cleaned_data.get('end_date')
+        distribution_type = forced_distribution_type or form.cleaned_data.get('distribution_type')
         facility = form.cleaned_data.get('facility')
+        active_distribution_type = distribution_type or ''
+        selected_distribution_type_label = dict(form.fields['distribution_type'].choices).get(
+            active_distribution_type,
+            'Semua Distribusi',
+        )
 
         qs = DistributionItem.objects.filter(
             distribution__status='DISTRIBUTED',
@@ -587,6 +615,9 @@ def reports_pengeluaran(request):
 
         if facility:
             qs = qs.filter(distribution__facility=facility)
+
+        if distribution_type:
+            qs = qs.filter(distribution__distribution_type=distribution_type)
 
         for di in qs:
             qty = di.quantity_approved if di.quantity_approved is not None else di.quantity_requested
@@ -607,7 +638,41 @@ def reports_pengeluaran(request):
 
         if request.GET.get('format') == 'excel' and report_data:
             selected_facility_name = facility.name if facility else 'Semua Fasilitas'
-            return export_pengeluaran_excel(report_data, start_date, end_date, selected_facility_name)
+            return export_pengeluaran_excel(
+                report_data,
+                start_date,
+                end_date,
+                selected_facility_name,
+                selected_distribution_type_label,
+            )
+
+    if tab_url_names is None:
+        tab_url_names = {
+            '': 'reports:pengeluaran',
+            'SPECIAL_REQUEST': 'reports:pengeluaran',
+            'ALLOCATION': 'reports:pengeluaran',
+            'LPLPO': 'reports:pengeluaran',
+        }
+
+    tab_choices = PengeluaranReportFilterForm.base_fields['distribution_type'].choices
+    tab_base_params = effective_querydict.copy()
+    tab_base_params.pop('format', None)
+    tab_base_params.pop('distribution_type', None)
+    tabs = []
+    for value, label in tab_choices:
+        tab_params = tab_base_params.copy()
+        tab_url = reverse(tab_url_names.get(value, base_report_url_name))
+        encoded_params = tab_params.urlencode()
+        if encoded_params:
+            tab_url = f'{tab_url}?{encoded_params}'
+        tabs.append(
+            {
+                'value': value,
+                'label': label,
+                'url': tab_url,
+                'active': value == active_distribution_type,
+            }
+        )
 
     total_quantity = sum(r['quantity'] for r in report_data)
     total_value = sum(r['total_price'] for r in report_data)
@@ -617,5 +682,9 @@ def reports_pengeluaran(request):
         'report_data': report_data,
         'total_quantity': total_quantity,
         'total_value': total_value,
+        'tabs': tabs,
+        'active_distribution_type': active_distribution_type,
+        'selected_distribution_type_label': selected_distribution_type_label,
+        'base_report_url_name': base_report_url_name,
     }
     return render(request, 'reports/pengeluaran.html', context)

--- a/backend/templates/reports/pengeluaran.html
+++ b/backend/templates/reports/pengeluaran.html
@@ -131,8 +131,8 @@
         LAPORAN PENGELUARAN / DISTRIBUSI<br>
         JENIS DISTRIBUSI: {{ selected_distribution_type_label }}<br>
         PERIODE: {{ form.start_date.value|default:"-" }} s/d {{ form.end_date.value|default:"-" }}
-        {% if form.facility.value %}
-        <br>FASILITAS: {{ form.facility.value }}
+        {% if selected_facility_name and selected_facility_name != "Semua Fasilitas" %}
+        <br>FASILITAS: {{ selected_facility_name }}
         {% endif %}
     </div>
 </div>

--- a/backend/templates/reports/pengeluaran.html
+++ b/backend/templates/reports/pengeluaran.html
@@ -53,12 +53,27 @@
 {% endblock %}
 
 {% block content %}
+<div class="row mb-4 d-print-none">
+    <div class="col-12">
+        <ul class="nav nav-pills gap-2">
+            {% for tab in tabs %}
+            <li class="nav-item">
+                <a href="{{ tab.url }}" class="nav-link {% if tab.active %}active{% else %}link-body-emphasis bg-light border{% endif %}">
+                    {{ tab.label }}
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
+
 <!-- Filter Bar -->
 <div class="row mb-4 d-print-none">
     <div class="col-12">
         <div class="card shadow-sm border-0">
             <div class="card-body bg-light">
                 <form method="get" class="row g-3 align-items-end">
+                    {{ form.distribution_type }}
                     <div class="col-md-auto">
                         {{ form.start_date.label_tag }}
                         {{ form.start_date }}
@@ -75,7 +90,7 @@
                         <button type="submit" class="btn btn-primary">
                             <i class="bi bi-filter"></i> Terapkan Filter
                         </button>
-                        <a href="{% url 'reports:pengeluaran' %}" class="btn btn-outline-secondary">Reset</a>
+                        <a href="{% url base_report_url_name %}" class="btn btn-outline-secondary">Reset</a>
                         <button type="button" class="btn btn-dark" data-action="print">
                             <i class="bi bi-printer"></i> Cetak Laporan
                         </button>
@@ -114,6 +129,7 @@
     </div>
     <div class="report-print-meta">
         LAPORAN PENGELUARAN / DISTRIBUSI<br>
+        JENIS DISTRIBUSI: {{ selected_distribution_type_label }}<br>
         PERIODE: {{ form.start_date.value|default:"-" }} s/d {{ form.end_date.value|default:"-" }}
         {% if form.facility.value %}
         <br>FASILITAS: {{ form.facility.value }}
@@ -169,7 +185,7 @@
                             <tr>
                                 <td colspan="11" class="text-center text-muted py-4">
                                     <i class="bi bi-inbox d-block mb-2" style="font-size: 2rem;"></i>
-                                    Tidak ada data pengeluaran untuk periode ini.
+                                    Tidak ada data pengeluaran {{ selected_distribution_type_label|lower }} untuk periode ini.
                                 </td>
                             </tr>
                             {% endif %}


### PR DESCRIPTION
# Pull Request

## Summary

- implement detailed pengeluaran/distribution reporting by `distribution_type`, including dedicated `/distribution/report/` routes, shared report rendering, filter-aware tabs, and export label updates
- address follow-up review feedback by reusing shared tab URL mappings, moving report renderer imports to module scope, and hiding the distribution report button for users without reports access
- add regression coverage for report endpoint permissions and distribution list report-button visibility

## Testing

- [x] Tests run locally (or explain why not)
  - `DB_PASSWORD=change-this-password docker compose up -d postgres`
  - `cd backend && . /tmp/dinkes-ims-venv/bin/activate && DJANGO_SECRET_KEY=test-secret-key-for-local-validation-only DB_PASSWORD=change-this-password DEBUG=True python manage.py test apps.reports.tests apps.distribution.tests --noinput`

## Documentation and release checklist

- [ ] Docs updated when models/routes/settings/scripts changed (`README.md`, `AGENTS.md`, `SYSTEM_MODEL.md`, `docs/developer_guide.md`, `backend/seed/README.md` as needed)
- [ ] If release-impacting, `VERSION` and `CHANGELOG.md` are updated in this PR