### PR TITLE
feat(csv): implement CSV export sanitization to neutralize formula-prefixed values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on Keep a Changelog and follows Semantic Versioning (`MAJOR.
 
 ## [Unreleased]
 
+### Fixed
+
+- Security hardening: neutralized CSV formula injection across custom CSV exports and django-import-export admin CSV downloads by sanitizing formula-prefixed cell values at export time.
+
 ## [1.24.0] - 2026-05-21
 
 ### Added

--- a/backend/apps/core/admin_mixins.py
+++ b/backend/apps/core/admin_mixins.py
@@ -1,5 +1,7 @@
 """Mixin for ImportExportModelAdmin that adds CSV column reference guide."""
 
+from import_export.formats import base_formats
+
 from apps.core.csv_exports import SanitizedCSV
 
 
@@ -22,8 +24,7 @@ class ImportGuideMixin:
             if file_format is SanitizedCSV:
                 sanitized_formats.append(file_format)
                 continue
-            extension_getter = getattr(file_format(), "get_extension", None)
-            if callable(extension_getter) and extension_getter() == "csv":
+            if issubclass(file_format, base_formats.CSV):
                 sanitized_formats.append(SanitizedCSV)
                 continue
             sanitized_formats.append(file_format)

--- a/backend/apps/core/admin_mixins.py
+++ b/backend/apps/core/admin_mixins.py
@@ -1,5 +1,7 @@
 """Mixin for ImportExportModelAdmin that adds CSV column reference guide."""
 
+from apps.core.csv_exports import SanitizedCSV
+
 
 class ImportGuideMixin:
     """Adds a CSV column reference table to the import page.
@@ -12,6 +14,22 @@ class ImportGuideMixin:
 
     import_guide = None
     import_template_name = 'admin/import_with_guide.html'
+
+    def get_export_formats(self):
+        formats = super().get_export_formats()
+        sanitized_formats = []
+        for file_format in formats:
+            if file_format is SanitizedCSV:
+                sanitized_formats.append(file_format)
+                continue
+            try:
+                if file_format().get_extension() == "csv":
+                    sanitized_formats.append(SanitizedCSV)
+                    continue
+            except Exception:
+                pass
+            sanitized_formats.append(file_format)
+        return sanitized_formats
 
     def get_import_context_data(self, **kwargs):
         context = super().get_import_context_data(**kwargs)

--- a/backend/apps/core/admin_mixins.py
+++ b/backend/apps/core/admin_mixins.py
@@ -22,12 +22,10 @@ class ImportGuideMixin:
             if file_format is SanitizedCSV:
                 sanitized_formats.append(file_format)
                 continue
-            try:
-                if file_format().get_extension() == "csv":
-                    sanitized_formats.append(SanitizedCSV)
-                    continue
-            except Exception:
-                pass
+            extension_getter = getattr(file_format(), "get_extension", None)
+            if callable(extension_getter) and extension_getter() == "csv":
+                sanitized_formats.append(SanitizedCSV)
+                continue
             sanitized_formats.append(file_format)
         return sanitized_formats
 

--- a/backend/apps/core/csv_exports.py
+++ b/backend/apps/core/csv_exports.py
@@ -1,0 +1,32 @@
+import csv
+from io import StringIO
+
+from import_export.formats import base_formats
+
+
+FORMULA_PREFIXES = ("=", "+", "-", "@")
+CSV_DELIMITER = ","
+
+
+def escape_csv_formula(value):
+    if not isinstance(value, str):
+        return value
+    if value.startswith(FORMULA_PREFIXES):
+        return f"'{value}"
+    return value
+
+
+def sanitize_csv_row(row):
+    return [escape_csv_formula(value) for value in row]
+
+
+class SanitizedCSV(base_formats.CSV):
+    def export_data(self, dataset, **kwargs):
+        stream = StringIO()
+        kwargs.setdefault("delimiter", CSV_DELIMITER)
+
+        writer = csv.writer(stream, **kwargs)
+        for row in dataset._package(dicts=False):
+            writer.writerow(sanitize_csv_row(row))
+
+        return stream.getvalue()

--- a/backend/apps/core/csv_exports.py
+++ b/backend/apps/core/csv_exports.py
@@ -11,7 +11,9 @@ CSV_DELIMITER = ","
 def escape_csv_formula(value):
     if not isinstance(value, str):
         return value
-    if value.startswith(FORMULA_PREFIXES):
+    if value.startswith("'"):
+        return value
+    if value.lstrip().startswith(FORMULA_PREFIXES):
         return f"'{value}"
     return value
 
@@ -26,7 +28,9 @@ class SanitizedCSV(base_formats.CSV):
         kwargs.setdefault("delimiter", CSV_DELIMITER)
 
         writer = csv.writer(stream, **kwargs)
-        for row in dataset._package(dicts=False):
+        if dataset.headers:
+            writer.writerow(sanitize_csv_row(dataset.headers))
+        for row in dataset:
             writer.writerow(sanitize_csv_row(row))
 
         return stream.getvalue()

--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import patch
+from import_export.formats import base_formats
 from tablib import Dataset
 
 from django.contrib.auth.models import AnonymousUser
@@ -18,6 +19,7 @@ from django.template import Context, Template
 from django.urls import resolve, reverse
 from django.utils import timezone
 
+from apps.core.admin_mixins import ImportGuideMixin
 from apps.core.context_processors import nav_notifications
 from apps.core.csv_exports import SanitizedCSV, escape_csv_formula
 from apps.core.forms import SystemSettingsForm
@@ -128,6 +130,23 @@ class CsvExportSecurityTests(SimpleTestCase):
 
         self.assertIn("Name,Notes", csv_output)
         self.assertIn("'\t=HYPERLINK", csv_output)
+
+    def test_import_guide_mixin_replaces_csv_subclasses_without_instantiating_them(self):
+        class NoInitCsvFormat(base_formats.CSV):
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("CSV format subclasses should not be instantiated here")
+
+        class NonCsvFormat:
+            pass
+
+        class ExportFormatsBase:
+            def get_export_formats(self):
+                return [NoInitCsvFormat, NonCsvFormat]
+
+        class TestAdmin(ImportGuideMixin, ExportFormatsBase):
+            pass
+
+        self.assertEqual(TestAdmin().get_export_formats(), [SanitizedCSV, NonCsvFormat])
 
 
 class SystemSettingsFormTests(SimpleTestCase):

--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 from datetime import timedelta
 from decimal import Decimal
 from unittest.mock import patch
+from tablib import Dataset
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
@@ -18,6 +19,7 @@ from django.urls import resolve, reverse
 from django.utils import timezone
 
 from apps.core.context_processors import nav_notifications
+from apps.core.csv_exports import SanitizedCSV, escape_csv_formula
 from apps.core.forms import SystemSettingsForm
 from apps.core.models import SystemSettings
 from apps.core.templatetags.number_format import safe_media_url
@@ -105,6 +107,27 @@ class SafeMediaUrlFilterTests(SimpleTestCase):
             safe_media_url("/media/settings/my-logo_v2.png"),
             "/media/settings/my-logo_v2.png",
         )
+
+
+class CsvExportSecurityTests(SimpleTestCase):
+    def test_escape_csv_formula_escapes_leading_whitespace_formulae(self):
+        for value in (" =SUM(A1:A2)", "\t=SUM(A1:A2)", "\r=SUM(A1:A2)"):
+            with self.subTest(value=value):
+                self.assertEqual(escape_csv_formula(value), f"'{value}")
+
+    def test_escape_csv_formula_does_not_double_escape_existing_apostrophe(self):
+        value = "'=SUM(A1:A2)"
+
+        self.assertEqual(escape_csv_formula(value), value)
+
+    def test_sanitized_csv_export_uses_headers_and_sanitizes_rows(self):
+        dataset = Dataset(headers=["Name", "Notes"])
+        dataset.append(["Paracetamol", "\t=HYPERLINK(\"http://example.com\")"])
+
+        csv_output = SanitizedCSV().export_data(dataset)
+
+        self.assertIn("Name,Notes", csv_output)
+        self.assertIn("'\t=HYPERLINK", csv_output)
 
 
 class SystemSettingsFormTests(SimpleTestCase):

--- a/backend/apps/expired/services.py
+++ b/backend/apps/expired/services.py
@@ -6,6 +6,7 @@ from django.http import StreamingHttpResponse
 from django.urls import reverse
 from django.utils import timezone
 
+from apps.core.csv_exports import sanitize_csv_row
 from apps.expired.models import Expired
 from apps.stock.models import Transaction
 
@@ -202,47 +203,51 @@ def export_expired_audit_report_csv(report_data):
         writer = csv.writer(_Echo())
         yield "\ufeff"
         yield writer.writerow(
-            [
-                "Outcome Type",
-                "Document Type",
-                "Document Reference",
-                "Kode Barang",
-                "Nama Barang",
-                "Batch / Lot",
-                "Expiry Date",
-                "Quantity",
-                "Unit Price",
-                "Total Price",
-                "Unit",
-                "Location",
-                "Funding Source",
-                "Responsible User",
-                "Timestamp",
-                "Notes / Reason",
-                "Item Reference",
-            ]
+            sanitize_csv_row(
+                [
+                    "Outcome Type",
+                    "Document Type",
+                    "Document Reference",
+                    "Kode Barang",
+                    "Nama Barang",
+                    "Batch / Lot",
+                    "Expiry Date",
+                    "Quantity",
+                    "Unit Price",
+                    "Total Price",
+                    "Unit",
+                    "Location",
+                    "Funding Source",
+                    "Responsible User",
+                    "Timestamp",
+                    "Notes / Reason",
+                    "Item Reference",
+                ]
+            )
         )
         for row in report_data["rows"]:
             yield writer.writerow(
-                [
-                    row["outcome_type"],
-                    row["document_type"],
-                    row["document_reference"],
-                    row["kode_barang"],
-                    row["nama_barang"],
-                    row["batch_lot"],
-                    row["expiry_date"].isoformat() if row["expiry_date"] else "",
-                    row["quantity"],
-                    row["unit_price"],
-                    row["total_price"],
-                    row["unit"],
-                    row["location"],
-                    row["funding_source"],
-                    row["responsible_user"],
-                    row["timestamp"].isoformat() if row["timestamp"] else "",
-                    row["notes"],
-                    row["reference_code"],
-                ]
+                sanitize_csv_row(
+                    [
+                        row["outcome_type"],
+                        row["document_type"],
+                        row["document_reference"],
+                        row["kode_barang"],
+                        row["nama_barang"],
+                        row["batch_lot"],
+                        row["expiry_date"].isoformat() if row["expiry_date"] else "",
+                        row["quantity"],
+                        row["unit_price"],
+                        row["total_price"],
+                        row["unit"],
+                        row["location"],
+                        row["funding_source"],
+                        row["responsible_user"],
+                        row["timestamp"].isoformat() if row["timestamp"] else "",
+                        row["notes"],
+                        row["reference_code"],
+                    ]
+                )
             )
 
     response = StreamingHttpResponse(

--- a/backend/apps/expired/tests.py
+++ b/backend/apps/expired/tests.py
@@ -521,6 +521,31 @@ class ExpiredWorkflowTest(TestCase):
         self.assertIn("Total Price", csv_output)
         self.assertNotIn("Distribusi uji", csv_output)
 
+    def test_expired_audit_report_csv_neutralizes_formula_prefixed_values(self):
+        expired_doc = self._create_expired(status=Expired.Status.DISPOSED)
+        expired_doc.disposed_by = self.user
+        expired_doc.disposed_at = timezone.make_aware(timezone.datetime(2026, 3, 18, 9, 0, 0))
+        expired_doc.save(update_fields=["disposed_by", "disposed_at", "updated_at"])
+        expired_doc.items.update(notes="=hapus-semua")
+
+        response = self.client.get(
+            reverse("expired:expired_audit_report"),
+            {
+                "start_date": "2026-03-01",
+                "end_date": "2026-03-31",
+                "date_field": "disposed_at",
+                "outcome_type": "BOTH",
+                "location": str(self.location.pk),
+                "item": str(self.item.pk),
+                "funding_source": str(self.funding_source.pk),
+                "format": "csv",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        csv_output = b"".join(response.streaming_content).decode("utf-8")
+        self.assertIn("'=hapus-semua", csv_output)
+
     def test_expired_audit_report_print_endpoint_returns_printable_html(self):
         response = self.client.get(
             reverse("expired:expired_audit_report"),

--- a/backend/apps/items/tests.py
+++ b/backend/apps/items/tests.py
@@ -1,10 +1,37 @@
+from django.contrib.admin.sites import AdminSite
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.urls import reverse
 
+from apps.core.csv_exports import SanitizedCSV
+from apps.items.admin import ItemAdmin, ItemResource
 from apps.items.forms import ItemForm
 from apps.items.models import Item, Unit, Category, Program
 from apps.users.models import User
+
+
+class ItemAdminCsvExportSecurityTest(TestCase):
+	def setUp(self):
+		self.unit = Unit.objects.create(code='TAB', name='Tablet')
+		self.category = Category.objects.create(code='OBAT', name='Obat')
+
+	def test_item_admin_uses_sanitized_csv_format(self):
+		admin = ItemAdmin(Item, AdminSite())
+
+		self.assertIn(SanitizedCSV, admin.get_export_formats())
+
+	def test_item_resource_csv_export_neutralizes_formula_prefixed_values(self):
+		item = Item.objects.create(
+			nama_barang='=HYPERLINK("http://example.com")',
+			satuan=self.unit,
+			kategori=self.category,
+		)
+
+		dataset = ItemResource().export(Item.objects.filter(pk=item.pk))
+		csv_output = SanitizedCSV().export_data(dataset)
+
+		self.assertIn("\"'=HYPERLINK", csv_output)
+		self.assertIn(item.kode_barang, csv_output)
 
 
 class LookupModelGuardrailTest(TestCase):

--- a/backend/apps/stock/tests.py
+++ b/backend/apps/stock/tests.py
@@ -1,17 +1,58 @@
 from decimal import Decimal
 from datetime import timedelta
+from datetime import date
 from unittest.mock import patch
 
+from django.contrib.admin.sites import AdminSite
 from django.db import IntegrityError
 from django.test import TestCase
 from django.test import SimpleTestCase
 from django.urls import reverse
 from django.utils import timezone
 
+from apps.core.csv_exports import SanitizedCSV
 from apps.users.models import User
+from apps.stock.admin import StockAdmin, StockResource
 from apps.items.models import Unit, Category, Item, Location, FundingSource
 from apps.stock.models import Stock, StockTransfer, Transaction
 from apps.core.models import SystemSettings
+
+
+class StockAdminCsvExportSecurityTest(TestCase):
+    def setUp(self):
+        self.unit = Unit.objects.create(code='TAB', name='Tablet')
+        self.category = Category.objects.create(code='OBAT', name='Obat', sort_order=1)
+        self.item = Item.objects.create(
+            nama_barang='Paracetamol 500mg',
+            satuan=self.unit,
+            kategori=self.category,
+            minimum_stock=Decimal('0'),
+        )
+        self.location = Location.objects.create(code='GUDANG', name='Gudang Utama')
+        self.funding = FundingSource.objects.create(code='APBD', name='APBD')
+
+    def test_stock_admin_uses_sanitized_csv_format(self):
+        admin = StockAdmin(Stock, AdminSite())
+
+        self.assertIn(SanitizedCSV, admin.get_export_formats())
+
+    def test_stock_resource_csv_export_neutralizes_formula_prefixed_values(self):
+        stock = Stock.objects.create(
+            item=self.item,
+            location=self.location,
+            batch_lot='@BATCH-01',
+            expiry_date=date(2027, 1, 1),
+            quantity=Decimal('25'),
+            reserved=Decimal('0'),
+            unit_price=Decimal('1000'),
+            sumber_dana=self.funding,
+        )
+
+        dataset = StockResource().export(Stock.objects.filter(pk=stock.pk))
+        csv_output = SanitizedCSV().export_data(dataset)
+
+        self.assertIn("'@BATCH-01", csv_output)
+        self.assertIn(self.item.kode_barang, csv_output)
 
 class StockCardTest(TestCase):
     def setUp(self):

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -124,6 +124,25 @@ class UserManagementViewsTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.target.username)
 
+    def test_user_export_csv_neutralizes_formula_prefixed_values(self):
+        User.objects.filter(pk=self.target.pk).update(
+            username="=cmd|' /C calc'!A0",
+            full_name="@full-name",
+            nip="-198801012010011001",
+            email="+user@example.com",
+        )
+
+        response = self.client.get(reverse("users:user_export_csv"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv; charset=utf-8")
+        csv_output = b"".join(response.streaming_content).decode("utf-8")
+        self.assertIn("'=cmd|' /C calc'!A0", csv_output)
+        self.assertIn("'@full-name", csv_output)
+        self.assertIn("'-198801012010011001", csv_output)
+        self.assertIn("'+user@example.com", csv_output)
+        self.assertIn("Aktif", csv_output)
+
     def test_user_create_success(self):
         payload = {
             "username": "auditor01",

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -11,6 +11,8 @@ from django.db.models import Q
 from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 
+from apps.core.csv_exports import sanitize_csv_row
+
 from .access import ROLE_DEFAULT_SCOPES, has_module_permission
 from .forms import UserCreateForm, UserUpdateForm
 from .models import ModuleAccess, User
@@ -566,23 +568,31 @@ def user_export_csv(request):
     def generate_rows():
         writer = csv.writer(_Echo())
         yield "\ufeff"
-        yield writer.writerow([
-            "Username", "Nama Lengkap", "NIP", "Email",
-            "Jabatan", "Fasilitas", "Status", "Login Terakhir",
-        ])
+        yield writer.writerow(
+            sanitize_csv_row(
+                [
+                    "Username", "Nama Lengkap", "NIP", "Email",
+                    "Jabatan", "Fasilitas", "Status", "Login Terakhir",
+                ]
+            )
+        )
         for user in queryset.iterator(chunk_size=200):
-            yield writer.writerow([
-                user.username,
-                user.full_name,
-                user.nip,
-                user.email,
-                role_map.get(user.role, user.role),
-                user.facility.name if user.facility else (
-                    "Instalasi Farmasi" if user.role != "PUSKESMAS" else ""
-                ),
-                "Aktif" if user.is_active else "Nonaktif",
-                user.last_login.strftime("%Y-%m-%d %H:%M") if user.last_login else "",
-            ])
+            yield writer.writerow(
+                sanitize_csv_row(
+                    [
+                        user.username,
+                        user.full_name,
+                        user.nip,
+                        user.email,
+                        role_map.get(user.role, user.role),
+                        user.facility.name if user.facility else (
+                            "Instalasi Farmasi" if user.role != "PUSKESMAS" else ""
+                        ),
+                        "Aktif" if user.is_active else "Nonaktif",
+                        user.last_login.strftime("%Y-%m-%d %H:%M") if user.last_login else "",
+                    ]
+                )
+            )
 
     response = StreamingHttpResponse(
         generate_rows(),


### PR DESCRIPTION
# Pull Request

## Summary

- Harden CSV export sanitization for spreadsheet formula injection by also escaping values whose first non-whitespace character is a formula prefix, while avoiding double-escaping values already prefixed with `'`.
- Keep django-import-export CSV handling on supported public APIs by iterating Tablib datasets via `headers` and row iteration instead of `_package(dicts=False)`.
- Update admin export format detection to replace CSV exports via `base_formats.CSV` subclass checks so sanitized CSV selection does not depend on broad exception handling or throwaway format instantiation.
- Add core regression coverage for whitespace-prefixed formula payloads, apostrophe-prefixed values, sanitized CSV header/row export behavior, and CSV subclass replacement without instantiation.

## Testing

- [x] Tests run locally (or explain why not): `DJANGO_SECRET_KEY=test-secret-key-for-local-validation-only DB_PASSWORD=change-this-password DEBUG=True python manage.py test apps.core.tests.test_core.CsvExportSecurityTests apps.users.tests.UserManagementViewsTest.test_user_export_csv_neutralizes_formula_prefixed_values apps.expired.tests.ExpiredWorkflowTest.test_expired_audit_report_csv_neutralizes_formula_prefixed_values apps.items.tests.ItemAdminCsvExportSecurityTest apps.stock.tests.StockAdminCsvExportSecurityTest --noinput`

## Documentation and release checklist

- [ ] Docs updated when models/routes/settings/scripts changed (`README.md`, `AGENTS.md`, `SYSTEM_MODEL.md`, `docs/developer_guide.md`, `backend/seed/README.md` as needed)
- [x] If release-impacting, `VERSION` and `CHANGELOG.md` are updated in this PR