### PR TITLE
Harden upload validation and audit logging

### DIFF
--- a/backend/apps/core/forms.py
+++ b/backend/apps/core/forms.py
@@ -1,8 +1,10 @@
 from django import forms
 from .models import SystemSettings
+from .upload_validation import validate_image_upload
 
 
 REQUIRED_NUMBERING_TOKENS = ("{seq}", "{year}")
+LOGO_MAX_SIZE_BYTES = 2 * 1024 * 1024
 
 class SystemSettingsForm(forms.ModelForm):
     class Meta:
@@ -31,6 +33,14 @@ class SystemSettingsForm(forms.ModelForm):
         logo = self.cleaned_data.get("logo")
         if logo is not None and logo is not False and not hasattr(logo, "read"):
             raise forms.ValidationError("Logo harus berupa file gambar, bukan URL.")
+        if logo and hasattr(logo, "read"):
+            self.cleaned_logo_mime_type = validate_image_upload(
+                logo,
+                max_size_bytes=LOGO_MAX_SIZE_BYTES,
+                field_label="Logo",
+                allowed_extensions={"png", "jpg", "jpeg", "webp"},
+                allowed_formats={"PNG", "JPEG", "WEBP"},
+            )
         return logo
 
     def clean_lplpo_distribution_number_template(self):

--- a/backend/apps/core/forms.py
+++ b/backend/apps/core/forms.py
@@ -33,7 +33,7 @@ class SystemSettingsForm(forms.ModelForm):
         logo = self.cleaned_data.get("logo")
         if logo is not None and logo is not False and not hasattr(logo, "read"):
             raise forms.ValidationError("Logo harus berupa file gambar, bukan URL.")
-        if logo and hasattr(logo, "read"):
+        if logo and hasattr(logo, "read") and not hasattr(logo, "url"):
             self.cleaned_logo_mime_type = validate_image_upload(
                 logo,
                 max_size_bytes=LOGO_MAX_SIZE_BYTES,

--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -1,3 +1,4 @@
+import json
 from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -39,6 +40,7 @@ from apps.puskesmas.models import PuskesmasRequest
 from apps.receiving.models import Receiving
 from apps.stock.models import Stock, Transaction
 from apps.users.models import ModuleAccess, User
+from PIL import Image
 
 
 class SemanticVersionTests(SimpleTestCase):
@@ -207,6 +209,54 @@ class SystemSettingsFormTests(SimpleTestCase):
 
         self.assertFalse(form.is_valid())
         self.assertIn("logo", form.errors)
+
+    def test_accepts_existing_logo_without_revalidation(self):
+        with TemporaryDirectory() as temp_dir:
+            logo_path = Path(temp_dir) / "settings" / "logo.png"
+            logo_path.parent.mkdir(parents=True, exist_ok=True)
+            logo_path.write_bytes(b"existing-logo")
+
+            with override_settings(MEDIA_ROOT=temp_dir):
+                form = SystemSettingsForm(
+                    data={
+                        "platform_label": "Healthcare IMS",
+                        "facility_name": "Instalasi Farmasi",
+                        "facility_address": "",
+                        "facility_phone": "",
+                        "header_title": "Dinas Kesehatan",
+                        "lplpo_distribution_number_template": "440/{seq}/SBBK.RF/{year}",
+                        "special_request_distribution_number_template": "440/{seq}/KD.F/{year}",
+                    },
+                    instance=SystemSettings(logo="settings/logo.png"),
+                )
+
+                self.assertTrue(form.is_valid(), form.errors)
+                self.assertEqual(form.cleaned_data["logo"].name, "settings/logo.png")
+
+    @patch("apps.core.upload_validation.Image.open", side_effect=Image.DecompressionBombError("bomb"))
+    def test_rejects_decompression_bomb_logo(self, mocked_image_open):
+        form = SystemSettingsForm(
+            data={
+                "platform_label": "Healthcare IMS",
+                "facility_name": "Instalasi Farmasi",
+                "facility_address": "",
+                "facility_phone": "",
+                "header_title": "Dinas Kesehatan",
+                "lplpo_distribution_number_template": "440/{seq}/SBBK.RF/{year}",
+                "special_request_distribution_number_template": "440/{seq}/KD.F/{year}",
+            },
+            files={
+                "logo": self._uploaded_file(
+                    "logo.png",
+                    b"not-a-real-image",
+                    "image/png",
+                )
+            },
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("logo", form.errors)
+        mocked_image_open.assert_called_once()
 
 
 class SystemSettingsModelTests(TestCase):
@@ -817,6 +867,38 @@ class SystemSettingsAccessTests(TestCase):
         self.assertTrue(
             any("system_settings_logo_upload_succeeded" in message for message in logs.output)
         )
+
+    def test_invalid_logo_upload_is_audit_logged_as_json(self):
+        user = User.objects.create_superuser(
+            username="settings-audit-fail-admin",
+            email="settings-audit-fail-admin@example.com",
+        )
+        self.client.force_login(user)
+
+        with self.assertLogs("security", level="WARNING") as logs:
+            response = self.client.post(
+                reverse("settings"),
+                {
+                    "platform_label": "Healthcare IMS",
+                    "facility_name": "Instalasi Farmasi",
+                    "facility_address": "",
+                    "facility_phone": "",
+                    "header_title": "Dinas Kesehatan",
+                    "lplpo_distribution_number_template": "440/{seq}/SBBK.RF/{year}",
+                    "special_request_distribution_number_template": "440/{seq}/KD.F/{year}",
+                    "logo": SimpleUploadedFile(
+                        'bad"\nlogo.png',
+                        b"not-a-real-image",
+                        content_type="image/png",
+                    ),
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(logs.output[0].split(":", 2)[2])
+        self.assertEqual(payload["event"], "system_settings_logo_upload_failed")
+        self.assertEqual(payload["filename"], 'bad"logo.png')
+        self.assertIn("logo", payload["errors"])
 
 
 class AdministrationHistoryAccessTests(TestCase):

--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -150,6 +150,10 @@ class CsvExportSecurityTests(SimpleTestCase):
 
 
 class SystemSettingsFormTests(SimpleTestCase):
+    @staticmethod
+    def _uploaded_file(name, content, content_type):
+        return SimpleUploadedFile(name, content, content_type)
+
     def test_accepts_valid_numbering_templates(self):
         form = SystemSettingsForm(
             data={
@@ -180,6 +184,29 @@ class SystemSettingsFormTests(SimpleTestCase):
 
         self.assertFalse(form.is_valid())
         self.assertIn("lplpo_distribution_number_template", form.errors)
+
+    def test_rejects_non_image_logo_with_png_extension(self):
+        form = SystemSettingsForm(
+            data={
+                "platform_label": "Healthcare IMS",
+                "facility_name": "Instalasi Farmasi",
+                "facility_address": "",
+                "facility_phone": "",
+                "header_title": "Dinas Kesehatan",
+                "lplpo_distribution_number_template": "440/{seq}/SBBK.RF/{year}",
+                "special_request_distribution_number_template": "440/{seq}/KD.F/{year}",
+            },
+            files={
+                "logo": self._uploaded_file(
+                    "logo.png",
+                    b"not-a-real-image",
+                    "image/png",
+                )
+            },
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("logo", form.errors)
 
 
 class SystemSettingsModelTests(TestCase):
@@ -752,6 +779,44 @@ class SystemSettingsAccessTests(TestCase):
         self.assertContains(response, "Preview Rule")
         self.assertContains(response, "440/12/SBBK.RF/2026")
         self.assertContains(response, "440/12/KD.F/2026")
+
+    def test_admin_user_logo_upload_is_audit_logged(self):
+        user = User.objects.create_superuser(
+            username="settings-audit-admin",
+            email="settings-audit-admin@example.com",
+            password="TestPassword123!",
+        )
+        self.client.force_login(user)
+
+        image_buffer = BytesIO()
+        from PIL import Image
+
+        Image.new("RGBA", (16, 16), (255, 0, 0, 255)).save(image_buffer, format="PNG")
+        image_buffer.seek(0)
+
+        with self.assertLogs("security", level="INFO") as logs:
+            response = self.client.post(
+                reverse("settings"),
+                {
+                    "platform_label": "Healthcare IMS",
+                    "facility_name": "Instalasi Farmasi",
+                    "facility_address": "",
+                    "facility_phone": "",
+                    "header_title": "Dinas Kesehatan",
+                    "lplpo_distribution_number_template": "440/{seq}/SBBK.RF/{year}",
+                    "special_request_distribution_number_template": "440/{seq}/KD.F/{year}",
+                    "logo": SimpleUploadedFile(
+                        "audit-logo.png",
+                        image_buffer.read(),
+                        content_type="image/png",
+                    ),
+                },
+            )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            any("system_settings_logo_upload_succeeded" in message for message in logs.output)
+        )
 
 
 class AdministrationHistoryAccessTests(TestCase):

--- a/backend/apps/core/upload_validation.py
+++ b/backend/apps/core/upload_validation.py
@@ -1,0 +1,156 @@
+import csv
+import io
+import re
+import unicodedata
+from pathlib import PurePath
+
+from django.core.exceptions import ValidationError
+from PIL import Image, UnidentifiedImageError
+
+
+WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^[a-zA-Z]:[\\/]")
+IMAGE_FORMAT_TO_MIME = {
+    "PNG": "image/png",
+    "JPEG": "image/jpeg",
+    "WEBP": "image/webp",
+}
+
+
+def sanitize_uploaded_filename(filename):
+    normalized = unicodedata.normalize("NFC", str(filename or "")).strip()
+    if not normalized:
+        raise ValidationError("Nama file wajib diisi.")
+    if "\x00" in normalized:
+        raise ValidationError("Nama file mengandung karakter null byte yang tidak diizinkan.")
+    if normalized.startswith(("/", "\\")) or WINDOWS_ABSOLUTE_PATH_RE.match(normalized):
+        raise ValidationError("Nama file tidak aman.")
+
+    path = PurePath(normalized.replace("\\", "/"))
+    if len(path.parts) != 1 or path.name in {".", ".."}:
+        raise ValidationError("Nama file tidak aman.")
+
+    return path.name
+
+
+def validate_uploaded_file_basics(uploaded_file, *, allowed_extensions, max_size_bytes, field_label):
+    if uploaded_file is None:
+        raise ValidationError(f"{field_label} wajib diisi.")
+
+    safe_name = sanitize_uploaded_filename(getattr(uploaded_file, "name", ""))
+    suffix = PurePath(safe_name).suffix.lower().lstrip(".")
+    normalized_extensions = {extension.lower().lstrip(".") for extension in allowed_extensions}
+    if suffix not in normalized_extensions:
+        allowed_list = ", ".join(sorted(f".{ext}" for ext in normalized_extensions))
+        raise ValidationError(
+            f"{field_label} harus memakai ekstensi yang diizinkan: {allowed_list}."
+        )
+
+    file_size = getattr(uploaded_file, "size", None)
+    if file_size is None:
+        raise ValidationError(f"Ukuran {field_label.lower()} tidak dapat dibaca.")
+    if file_size > max_size_bytes:
+        max_size_mb = max_size_bytes / (1024 * 1024)
+        raise ValidationError(
+            f"{field_label} melebihi batas ukuran {max_size_mb:.0f} MB."
+        )
+
+    uploaded_file.name = safe_name
+    return safe_name
+
+
+def validate_csv_upload(uploaded_file, *, max_size_bytes):
+    validate_uploaded_file_basics(
+        uploaded_file,
+        allowed_extensions={"csv"},
+        max_size_bytes=max_size_bytes,
+        field_label="File CSV",
+    )
+
+    try:
+        sample = uploaded_file.read(min(uploaded_file.size, 4096))
+    finally:
+        uploaded_file.seek(0)
+
+    try:
+        decoded = sample.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise ValidationError("File CSV harus menggunakan encoding UTF-8.") from exc
+
+    if not decoded.strip():
+        raise ValidationError("File CSV tidak boleh kosong.")
+    if "\x00" in decoded:
+        raise ValidationError("File CSV mengandung null byte yang tidak diizinkan.")
+
+    try:
+        rows = list(csv.reader(io.StringIO(decoded)))
+    except csv.Error as exc:
+        raise ValidationError("File CSV tidak valid.") from exc
+
+    if not rows or not rows[0] or len(rows[0]) < 2:
+        raise ValidationError("Konten file CSV tidak valid.")
+
+    return uploaded_file
+
+
+def validate_image_upload(
+    uploaded_file,
+    *,
+    max_size_bytes,
+    field_label,
+    allowed_extensions,
+    allowed_formats,
+):
+    validate_uploaded_file_basics(
+        uploaded_file,
+        allowed_extensions=allowed_extensions,
+        max_size_bytes=max_size_bytes,
+        field_label=field_label,
+    )
+
+    try:
+        with Image.open(uploaded_file) as image:
+            image.verify()
+
+        uploaded_file.seek(0)
+        with Image.open(uploaded_file) as image:
+            image_format = (image.format or "").upper()
+    except (UnidentifiedImageError, OSError) as exc:
+        raise ValidationError(f"{field_label} harus berupa file gambar yang valid.") from exc
+    finally:
+        uploaded_file.seek(0)
+
+    if image_format not in allowed_formats:
+        allowed_list = ", ".join(sorted(allowed_formats))
+        raise ValidationError(
+            f"{field_label} harus memakai format gambar yang diizinkan: {allowed_list}."
+        )
+
+    return IMAGE_FORMAT_TO_MIME[image_format]
+
+
+def validate_receiving_document_upload(uploaded_file, *, max_size_bytes):
+    validate_uploaded_file_basics(
+        uploaded_file,
+        allowed_extensions={"pdf", "png", "jpg", "jpeg"},
+        max_size_bytes=max_size_bytes,
+        field_label="Dokumen lampiran",
+    )
+
+    suffix = PurePath(uploaded_file.name).suffix.lower()
+    if suffix == ".pdf":
+        try:
+            signature = uploaded_file.read(5)
+        finally:
+            uploaded_file.seek(0)
+
+        if signature != b"%PDF-":
+            raise ValidationError("Dokumen lampiran PDF tidak valid.")
+        return "application/pdf"
+
+    return validate_image_upload(
+        uploaded_file,
+        max_size_bytes=max_size_bytes,
+        field_label="Dokumen lampiran",
+        allowed_extensions={"png", "jpg", "jpeg"},
+        allowed_formats={"PNG", "JPEG"},
+    )

--- a/backend/apps/core/upload_validation.py
+++ b/backend/apps/core/upload_validation.py
@@ -66,6 +66,15 @@ def validate_csv_upload(uploaded_file, *, max_size_bytes):
         field_label="File CSV",
     )
 
+    content_type = (
+        (getattr(uploaded_file, "content_type", "") or "")
+        .split(";", 1)[0]
+        .strip()
+        .lower()
+    )
+    if content_type not in {"text/csv", "application/csv", "application/vnd.ms-excel"}:
+        raise ValidationError("Tipe file CSV tidak valid.")
+
     try:
         sample = uploaded_file.read(min(uploaded_file.size, 4096))
     finally:
@@ -114,7 +123,7 @@ def validate_image_upload(
         uploaded_file.seek(0)
         with Image.open(uploaded_file) as image:
             image_format = (image.format or "").upper()
-    except (UnidentifiedImageError, OSError) as exc:
+    except (Image.DecompressionBombError, UnidentifiedImageError, OSError) as exc:
         raise ValidationError(f"{field_label} harus berupa file gambar yang valid.") from exc
     finally:
         uploaded_file.seek(0)

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import render
@@ -480,13 +481,16 @@ class SystemSettingsUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateVi
 
     def form_valid(self, form):
         logo = form.cleaned_data.get("logo")
-        if logo and hasattr(logo, "read"):
+        if logo and hasattr(logo, "read") and not hasattr(logo, "url"):
             security_logger.info(
-                'event="system_settings_logo_upload_succeeded" username="%s" filename="%s" mime_type="%s"'
-                % (
-                    self.request.user.username,
-                    logo.name,
-                    getattr(form, "cleaned_logo_mime_type", "unknown"),
+                json.dumps(
+                    {
+                        "event": "system_settings_logo_upload_succeeded",
+                        "filename": logo.name,
+                        "mime_type": getattr(form, "cleaned_logo_mime_type", "unknown"),
+                        "username": self.request.user.username,
+                    },
+                    sort_keys=True,
                 )
             )
         messages.success(self.request, "Pengaturan sistem berhasil diperbarui.")
@@ -495,11 +499,14 @@ class SystemSettingsUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateVi
     def form_invalid(self, form):
         if self.request.method == "POST" and self.request.FILES.get("logo"):
             security_logger.warning(
-                'event="system_settings_logo_upload_failed" username="%s" filename="%s" errors="%s"'
-                % (
-                    self.request.user.username,
-                    self.request.FILES["logo"].name,
-                    form.errors.as_json(),
+                json.dumps(
+                    {
+                        "event": "system_settings_logo_upload_failed",
+                        "errors": json.loads(form.errors.as_json()),
+                        "filename": self.request.FILES["logo"].name,
+                        "username": self.request.user.username,
+                    },
+                    sort_keys=True,
                 )
             )
         return super().form_invalid(form)

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -479,5 +479,27 @@ class SystemSettingsUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateVi
         return (template or "").replace("{seq}", sequence).replace("{year}", year)
 
     def form_valid(self, form):
+        logo = form.cleaned_data.get("logo")
+        if logo and hasattr(logo, "read"):
+            security_logger.info(
+                'event="system_settings_logo_upload_succeeded" username="%s" filename="%s" mime_type="%s"'
+                % (
+                    self.request.user.username,
+                    logo.name,
+                    getattr(form, "cleaned_logo_mime_type", "unknown"),
+                )
+            )
         messages.success(self.request, "Pengaturan sistem berhasil diperbarui.")
         return super().form_valid(form)
+
+    def form_invalid(self, form):
+        if self.request.method == "POST" and self.request.FILES.get("logo"):
+            security_logger.warning(
+                'event="system_settings_logo_upload_failed" username="%s" filename="%s" errors="%s"'
+                % (
+                    self.request.user.username,
+                    self.request.FILES["logo"].name,
+                    form.errors.as_json(),
+                )
+            )
+        return super().form_invalid(form)

--- a/backend/apps/receiving/admin.py
+++ b/backend/apps/receiving/admin.py
@@ -65,19 +65,17 @@ class ReceivingDocumentInlineForm(forms.ModelForm):
 
     def clean_file(self):
         uploaded_file = self.cleaned_data.get("file")
-        if not uploaded_file:
-            return uploaded_file
-
-        self.cleaned_file_type = validate_receiving_document_upload(
-            uploaded_file,
-            max_size_bytes=RECEIVING_DOCUMENT_MAX_SIZE_BYTES,
-        )
+        if uploaded_file and not hasattr(uploaded_file, "url"):
+            self.cleaned_file_type = validate_receiving_document_upload(
+                uploaded_file,
+                max_size_bytes=RECEIVING_DOCUMENT_MAX_SIZE_BYTES,
+            )
         return uploaded_file
 
     def save(self, commit=True):
         instance = super().save(commit=False)
         uploaded_file = self.cleaned_data.get("file")
-        if uploaded_file:
+        if uploaded_file and not hasattr(uploaded_file, "url"):
             instance.file_name = uploaded_file.name
             instance.file_type = getattr(self, "cleaned_file_type", instance.file_type)
         if commit:

--- a/backend/apps/receiving/admin.py
+++ b/backend/apps/receiving/admin.py
@@ -1,6 +1,11 @@
+import json
+import logging
+from csv import Error as CSVError
+
 from django.contrib import admin
 from django.shortcuts import render, redirect
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.urls import path
 from django import forms
 from django.db import transaction
@@ -20,7 +25,13 @@ from .models import (
     ReceivingTypeOption,
 )
 from apps.items.models import Item, FundingSource, Location, Supplier
+from apps.core.upload_validation import validate_csv_upload, validate_receiving_document_upload
 from apps.stock.models import Stock, Transaction
+
+
+logger = logging.getLogger("security")
+CSV_IMPORT_MAX_SIZE_BYTES = 2 * 1024 * 1024
+RECEIVING_DOCUMENT_MAX_SIZE_BYTES = 10 * 1024 * 1024
 
 
 # ── Inlines ────────────────────────────────────────────────
@@ -47,8 +58,36 @@ class ReceivingOrderItemInline(admin.TabularInline):
     raw_id_fields = ("item",)
 
 
+class ReceivingDocumentInlineForm(forms.ModelForm):
+    class Meta:
+        model = ReceivingDocument
+        fields = "__all__"
+
+    def clean_file(self):
+        uploaded_file = self.cleaned_data.get("file")
+        if not uploaded_file:
+            return uploaded_file
+
+        self.cleaned_file_type = validate_receiving_document_upload(
+            uploaded_file,
+            max_size_bytes=RECEIVING_DOCUMENT_MAX_SIZE_BYTES,
+        )
+        return uploaded_file
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+        uploaded_file = self.cleaned_data.get("file")
+        if uploaded_file:
+            instance.file_name = uploaded_file.name
+            instance.file_type = getattr(self, "cleaned_file_type", instance.file_type)
+        if commit:
+            instance.save()
+        return instance
+
+
 class ReceivingDocumentInline(admin.TabularInline):
     model = ReceivingDocument
+    form = ReceivingDocumentInlineForm
     extra = 0
     fields = ("file", "file_name", "file_type")
 
@@ -71,6 +110,13 @@ class ReceivingCSVImportForm(forms.Form):
         "supplier_code, sumber_dana_code, location_code, item_code, "
         "quantity, batch_lot, expiry_date, unit_price",
     )
+
+    def clean_csv_file(self):
+        csv_file = self.cleaned_data.get("csv_file")
+        return validate_csv_upload(
+            csv_file,
+            max_size_bytes=CSV_IMPORT_MAX_SIZE_BYTES,
+        )
 
 
 # ── Admin ──────────────────────────────────────────────────
@@ -97,6 +143,30 @@ class ReceivingAdmin(admin.ModelAdmin):
 
     change_list_template = "admin/receiving/receiving_changelist.html"
 
+    def save_formset(self, request, form, formset, change):
+        if formset.model is not ReceivingDocument:
+            return super().save_formset(request, form, formset, change)
+
+        instances = formset.save(commit=False)
+        for deleted in formset.deleted_objects:
+            deleted.delete()
+
+        for instance in instances:
+            is_new = instance.pk is None
+            instance.save()
+            security_logger_payload = {
+                "event": "receiving_document_upload_succeeded",
+                "username": request.user.username,
+                "receiving_id": instance.receiving_id,
+                "document_id": instance.pk,
+                "filename": instance.file_name,
+                "mime_type": instance.file_type,
+                "created": is_new,
+            }
+            logger.info(json.dumps(security_logger_payload, sort_keys=True))
+
+        formset.save_m2m()
+
     def get_urls(self):
         urls = super().get_urls()
         custom_urls = [
@@ -110,13 +180,39 @@ class ReceivingAdmin(admin.ModelAdmin):
 
     def import_csv_view(self, request):
         """Custom CSV import view for bulk receiving + stock creation."""
+        if not self.has_add_permission(request):
+            logger.warning(
+                json.dumps(
+                    {
+                        "event": "receiving_csv_import_denied",
+                        "username": getattr(request.user, "username", "anonymous"),
+                    },
+                    sort_keys=True,
+                )
+            )
+            raise PermissionDenied
+
         if request.method == "POST":
             form = ReceivingCSVImportForm(request.POST, request.FILES)
             if form.is_valid():
                 try:
                     result = self._process_csv(
-                        request.FILES["csv_file"],
+                        form.cleaned_data["csv_file"],
                         request.user,
+                    )
+                    logger.info(
+                        json.dumps(
+                            {
+                                "event": "receiving_csv_import_succeeded",
+                                "filename": form.cleaned_data["csv_file"].name,
+                                "receivings": result["receivings"],
+                                "items": result["items"],
+                                "stock": result["stock"],
+                                "transactions": result["transactions"],
+                                "username": request.user.username,
+                            },
+                            sort_keys=True,
+                        )
                     )
                     messages.success(
                         request,
@@ -125,8 +221,31 @@ class ReceivingAdmin(admin.ModelAdmin):
                         f"{result['transactions']} transaksi dibuat.",
                     )
                     return redirect("..")
-                except Exception as e:
-                    messages.error(request, f"Import gagal: {e}")
+                except (UnicodeDecodeError, CSVError, ValueError) as exc:
+                    logger.warning(
+                        json.dumps(
+                            {
+                                "event": "receiving_csv_import_failed",
+                                "filename": form.cleaned_data["csv_file"].name,
+                                "reason": str(exc),
+                                "username": request.user.username,
+                            },
+                            sort_keys=True,
+                        )
+                    )
+                    messages.error(request, f"Import gagal: {exc}")
+                except Exception:
+                    logger.exception(
+                        json.dumps(
+                            {
+                                "event": "receiving_csv_import_crashed",
+                                "filename": form.cleaned_data["csv_file"].name,
+                                "username": request.user.username,
+                            },
+                            sort_keys=True,
+                        )
+                    )
+                    messages.error(request, "Import gagal karena kesalahan internal.")
         else:
             form = ReceivingCSVImportForm()
 
@@ -391,10 +510,19 @@ class ReceivingAdmin(admin.ModelAdmin):
         if not value:
             return Decimal("0")
         try:
-            return Decimal(value)
+            decimal_value = Decimal(value)
         except (InvalidOperation, ValueError) as exc:
             if row_num is not None:
                 raise ValueError(
                     f"Baris {row_num}: format {field_name} tidak valid: '{value}'"
                 ) from exc
             raise ValueError(f"Format {field_name} tidak valid: '{value}'") from exc
+
+        if not decimal_value.is_finite():
+            if row_num is not None:
+                raise ValueError(
+                    f"Baris {row_num}: {field_name} tidak boleh NaN atau Infinity"
+                )
+            raise ValueError(f"{field_name} tidak boleh NaN atau Infinity")
+
+        return decimal_value

--- a/backend/apps/receiving/tests.py
+++ b/backend/apps/receiving/tests.py
@@ -3,7 +3,6 @@ from datetime import date
 from decimal import Decimal
 
 from django.contrib.admin.sites import AdminSite
-from django.contrib.auth.models import Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.urls import reverse
@@ -84,6 +83,21 @@ class ReceivingCSVImportTest(TestCase):
                     "receiving.csv",
                     b"\x89PNG\r\n\x1a\n",
                     content_type="text/csv",
+                )
+            },
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("csv_file", form.errors)
+
+    def test_csv_import_form_rejects_non_csv_mime_type(self):
+        form = ReceivingCSVImportForm(
+            data={},
+            files={
+                "csv_file": self._uploaded_file(
+                    "receiving.csv",
+                    b"document_number,receiving_type\nRCV-1,GRANT\n",
+                    content_type="application/octet-stream",
                 )
             },
         )
@@ -814,3 +828,39 @@ class ReceivingDocumentUploadValidationTest(TestCase):
         document = form.save(commit=False)
         self.assertEqual(document.file_name, "dokumen.jpg")
         self.assertEqual(document.file_type, "image/jpeg")
+
+    def test_receiving_document_form_accepts_existing_file_without_revalidation(self):
+        from apps.receiving.admin import ReceivingDocumentInlineForm
+
+        user = User.objects.create_superuser(
+            username="doc-existing-admin",
+        )
+        funding = FundingSource.objects.create(code="DOCEXIST", name="Doc Existing")
+        receiving = Receiving.objects.create(
+            document_number="RCV-2026-DOCEXIST",
+            receiving_type=Receiving.ReceivingType.GRANT,
+            receiving_date=date(2026, 3, 16),
+            sumber_dana=funding,
+            status=Receiving.Status.DRAFT,
+            created_by=user,
+        )
+        document = ReceivingDocument.objects.create(
+            receiving=receiving,
+            file="receiving/2026/06/dokumen.pdf",
+            file_name="dokumen.pdf",
+            file_type="application/pdf",
+        )
+
+        form = ReceivingDocumentInlineForm(
+            data={
+                "receiving": receiving.pk,
+                "file_name": document.file_name,
+                "file_type": document.file_type,
+            },
+            instance=document,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        saved_document = form.save(commit=False)
+        self.assertEqual(saved_document.file_name, "dokumen.pdf")
+        self.assertEqual(saved_document.file_type, "application/pdf")

--- a/backend/apps/receiving/tests.py
+++ b/backend/apps/receiving/tests.py
@@ -1,14 +1,16 @@
+from io import BytesIO
 from datetime import date
 from decimal import Decimal
 
 from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.urls import reverse
 
 from apps.distribution.models import Distribution, DistributionItem
 from apps.items.models import Category, Facility, FundingSource, Item, Location, Unit
-from apps.receiving.admin import ReceivingAdmin
+from apps.receiving.admin import ReceivingAdmin, ReceivingCSVImportForm
 from apps.receiving.forms import (
     PlannedReceivingForm,
     ReceivingForm,
@@ -16,6 +18,7 @@ from apps.receiving.forms import (
 )
 from apps.receiving.models import (
     Receiving,
+    ReceivingDocument,
     ReceivingItem,
     ReceivingOrderItem,
     ReceivingTypeOption,
@@ -53,6 +56,40 @@ class ReceivingCSVImportTest(TestCase):
             content.encode("utf-8"),
             content_type="text/csv",
         )
+
+    @staticmethod
+    def _uploaded_file(name, content, content_type="text/plain"):
+        return SimpleUploadedFile(name, content, content_type=content_type)
+
+    def test_csv_import_form_rejects_non_csv_extension(self):
+        form = ReceivingCSVImportForm(
+            data={},
+            files={
+                "csv_file": self._uploaded_file(
+                    "receiving.pdf",
+                    b"%PDF-1.4\n",
+                    content_type="application/pdf",
+                )
+            },
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("csv_file", form.errors)
+
+    def test_csv_import_form_rejects_non_csv_content(self):
+        form = ReceivingCSVImportForm(
+            data={},
+            files={
+                "csv_file": self._uploaded_file(
+                    "receiving.csv",
+                    b"\x89PNG\r\n\x1a\n",
+                    content_type="text/csv",
+                )
+            },
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("csv_file", form.errors)
 
     def test_process_csv_applies_defaults_for_empty_optional_fields(self):
         csv_content = (
@@ -111,6 +148,49 @@ class ReceivingCSVImportTest(TestCase):
             ValueError, "Baris 2: format quantity tidak valid: 'sepuluh'"
         ):
             self.admin._process_csv(self._csv_file(csv_content), self.user)
+
+    def test_process_csv_rejects_nan_decimal(self):
+        csv_content = (
+            "document_number,receiving_type,receiving_date,supplier_code,sumber_dana_code,"
+            "location_code,item_code,quantity,batch_lot,expiry_date,unit_price\n"
+            "RCV-2026-00001,GRANT,12/03/2026,,APBD,GUDANG,ITM-TEST-0001,NaN,B-001,01/01/2030,1000\n"
+        )
+
+        with self.assertRaisesMessage(
+            ValueError, "Baris 2: quantity tidak boleh NaN atau Infinity"
+        ):
+            self.admin._process_csv(self._csv_file(csv_content), self.user)
+
+    def test_import_view_requires_add_permission(self):
+        user = User.objects.create_user(
+            username="receiving_staff",
+            password="secret12345",
+            is_staff=True,
+        )
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("admin:receiving_import_csv"))
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_import_view_logs_success(self):
+        self.client.force_login(self.user)
+        csv_content = (
+            "document_number,receiving_type,receiving_date,supplier_code,sumber_dana_code,"
+            "location_code,item_code,quantity,batch_lot,expiry_date,unit_price\n"
+            "RCV-2026-00001,GRANT,12/03/2026,,APBD,GUDANG,ITM-TEST-0001,10,B-001,01/01/2030,1000\n"
+        )
+
+        with self.assertLogs("security", level="INFO") as logs:
+            response = self.client.post(
+                reverse("admin:receiving_import_csv"),
+                {"csv_file": self._csv_file(csv_content)},
+            )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            any("receiving_csv_import_succeeded" in message for message in logs.output)
+        )
 
     def test_process_csv_missing_required_header_rejected(self):
         csv_content = (
@@ -220,6 +300,7 @@ class ReceivingWorkflowCleanupTest(TestCase):
         self.assertEqual(trx.reference_type, Transaction.ReferenceType.RECEIVING)
         self.assertEqual(trx.transaction_type, Transaction.TransactionType.IN)
         self.assertEqual(trx.quantity, Decimal("10"))
+
 
     def test_plan_close_blocked_when_remaining_items_not_cancelled(self):
         receiving = Receiving.objects.create(
@@ -671,3 +752,65 @@ class ReceivingWorkflowCleanupTest(TestCase):
             reverse("receiving:receiving_plan_approve", args=[receiving.pk])
         )
         self.assertEqual(response.status_code, 403)
+
+
+class ReceivingDocumentUploadValidationTest(TestCase):
+    def test_receiving_document_form_rejects_invalid_pdf_content(self):
+        from apps.receiving.admin import ReceivingDocumentInlineForm
+
+        form = ReceivingDocumentInlineForm(
+            data={"file_name": "", "file_type": ""},
+            files={
+                "file": SimpleUploadedFile(
+                    "dokumen.pdf",
+                    b"not-a-pdf",
+                    content_type="application/pdf",
+                )
+            },
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("file", form.errors)
+
+    def test_receiving_document_form_sets_detected_metadata(self):
+        from apps.receiving.admin import ReceivingDocumentInlineForm
+
+        user = User.objects.create_superuser(
+            username="doc-metadata-admin",
+            password="secret12345",
+        )
+        funding = FundingSource.objects.create(code="DOCMETA", name="Doc Metadata")
+        receiving = Receiving.objects.create(
+            document_number="RCV-2026-DOCMETA",
+            receiving_type=Receiving.ReceivingType.GRANT,
+            receiving_date=date(2026, 3, 16),
+            sumber_dana=funding,
+            status=Receiving.Status.DRAFT,
+            created_by=user,
+        )
+
+        image_buffer = BytesIO()
+        from PIL import Image
+
+        Image.new("RGB", (10, 10), (255, 255, 255)).save(image_buffer, format="JPEG")
+        image_buffer.seek(0)
+
+        form = ReceivingDocumentInlineForm(
+            data={
+                "receiving": receiving.pk,
+                "file_name": "manual name",
+                "file_type": "manual/type",
+            },
+            files={
+                "file": SimpleUploadedFile(
+                    "dokumen.jpg",
+                    image_buffer.read(),
+                    content_type="image/jpeg",
+                )
+            },
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        document = form.save(commit=False)
+        self.assertEqual(document.file_name, "dokumen.jpg")
+        self.assertEqual(document.file_type, "image/jpeg")


### PR DESCRIPTION
## Summary
- add shared server-side upload validation for CSV, image, and receiving document files
- harden receiving CSV import with explicit permission checks, narrower error handling, and audit logging
- add regression coverage for rejected uploads, audit logging, and import validation edge cases

## Validation
- python manage.py test apps.receiving.tests apps.core.tests.test_core

## Issue
- Closes #96