### PR TITLE
Add rate limiting to sensitive POST endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,12 @@ CSRF_TRUSTED_ORIGINS=http://localhost:8000
 # Email backend (defaults to console in development)
 EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
 
+# Sensitive POST rate limits
+USER_BULK_ACTION_RATE_LIMIT=10/m
+USER_MUTATION_RATE_LIMIT=20/m
+USER_PASSWORD_RESET_RATE_LIMIT=5/m
+PASSWORD_CHANGE_RATE_LIMIT=5/m
+
 # Maximum number of POST fields allowed per request.
 # Increase if LPLPO or other wide forms exceed Django's default limit.
 DATA_UPLOAD_MAX_NUMBER_FIELDS=10000

--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,11 @@ CSRF_TRUSTED_ORIGINS=http://localhost:8000
 # Email backend (defaults to console in development)
 EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
 
+# Redis cache URL (used by django-ratelimit for shared counters across workers)
+REDIS_URL=redis://127.0.0.1:6379/1
+
 # Sensitive POST rate limits
+RATELIMIT_FAIL_OPEN=True
 USER_BULK_ACTION_RATE_LIMIT=10/m
 USER_MUTATION_RATE_LIMIT=20/m
 USER_PASSWORD_RESET_RATE_LIMIT=5/m

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,7 @@ Apply these principles:
 - Keep `DEBUG=False` production hardening documented and synchronized with settings.
 - Keep import workflow docs aligned with dry-run/confirm semantics from django-import-export.
 - Keep axes backend ordering and middleware placement documented exactly as configured.
+- Keep sensitive POST throttling settings and the centralized `429` behavior documented exactly as configured.
 
 ## Development Commands
 
@@ -163,6 +164,13 @@ Before opening a PR, verify:
 - Env vars in docs exist in `.env.example` or settings usage.
 - Security behavior in docs mirrors `backend/config/settings.py`.
 - CSV column docs match actual import resources/forms/admin parser logic.
+
+## Sensitive POST Throttling
+
+- `django-axes` remains the login brute-force control.
+- Additional authenticated POST throttling uses `django-ratelimit`.
+- Current settings-backed knobs are `USER_BULK_ACTION_RATE_LIMIT`, `USER_MUTATION_RATE_LIMIT`, `USER_PASSWORD_RESET_RATE_LIMIT`, and `PASSWORD_CHANGE_RATE_LIMIT`.
+- Throttled requests must continue through the centralized error pipeline and render as HTTP `429`.
 
 ## URL Routing Convention
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,8 +169,11 @@ Before opening a PR, verify:
 
 - `django-axes` remains the login brute-force control.
 - Additional authenticated POST throttling uses `django-ratelimit`.
+- Counters use a shared Redis cache (`CACHES["default"]` → `RATELIMIT_USE_CACHE`) so limits are consistent across gunicorn workers.
+- `RATELIMIT_FAIL_OPEN=True` is the default so rate-limiting degrades gracefully when Redis is unavailable.
 - Current settings-backed knobs are `USER_BULK_ACTION_RATE_LIMIT`, `USER_MUTATION_RATE_LIMIT`, `USER_PASSWORD_RESET_RATE_LIMIT`, and `PASSWORD_CHANGE_RATE_LIMIT`.
 - Throttled requests must continue through the centralized error pipeline and render as HTTP `429`.
+- `@user_mutation_ratelimit` covers all user mutation endpoints: create, update, toggle-active, and delete.
 
 ## URL Routing Convention
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Solusi ini membantu proses inventaris berjalan lebih konsisten melalui alur doku
 | Antarmuka | Django Templates + Bootstrap 5 |
 | Form | django-crispy-forms + crispy-bootstrap5 |
 | Import Data | django-import-export |
-| Keamanan | django-axes |
+| Keamanan | django-axes + django-ratelimit |
 
 ## Kapabilitas Utama
 
@@ -78,6 +78,7 @@ Rincian skema kanonis tersedia di `SYSTEM_MODEL.md`.
 ## Keamanan
 
 - Perlindungan brute-force login menggunakan `django-axes`.
+- Rate limiting untuk endpoint POST sensitif seperti perubahan password dan aksi manajemen pengguna menggunakan `django-ratelimit`.
 - Validasi kata sandi kuat dengan minimum 10 karakter dan validator kustom tambahan.
 - Kombinasi pengamanan sesi dan CSRF dengan `HttpOnly` serta `SameSite=Lax`.
 - Hardening produksi aktif saat `DEBUG=False`, termasuk secure cookie dan header keamanan terkait.

--- a/SYSTEM_MODEL.md
+++ b/SYSTEM_MODEL.md
@@ -2,8 +2,8 @@
 
 Canonical reference for current schema, route topology, permission model, and stock mutation behavior.
 
-Last verified: 2026-05-20
-Verification sources: `backend/apps/*/models.py`, `backend/config/urls.py`, `backend/apps/*/urls.py`, `backend/apps/core/decorators.py`, `backend/apps/users/access.py`, `backend/config/settings.py`, `backend/apps/receiving/admin.py`, `backend/apps/distribution/services.py`, `backend/apps/allocation/services.py`, `backend/apps/stock/views.py`, `backend/apps/lplpo/models.py`
+Last verified: 2026-06-04
+Verification sources: `backend/apps/*/models.py`, `backend/config/urls.py`, `backend/apps/*/urls.py`, `backend/apps/core/decorators.py`, `backend/apps/users/access.py`, `backend/config/settings.py`, `backend/apps/receiving/admin.py`, `backend/apps/distribution/services.py`, `backend/apps/allocation/services.py`, `backend/apps/stock/views.py`, `backend/apps/lplpo/models.py`, `backend/apps/core/rate_limits.py`, `backend/apps/users/views.py`
 
 ## 1) Domain Overview
 
@@ -30,6 +30,7 @@ Root route include map from `backend/config/urls.py`:
 - `/` -> dashboard (`apps.core.views.dashboard`)
 - `/admin/` -> Django admin
 - `/login/`, `/logout/`, `/password/change/`, `/password/change/done/`
+  - `/password/change/` uses a rate-limited subclass of Django's `PasswordChangeView`
 - `/settings/` -> system settings (`apps.core.views.SystemSettingsUpdateView`)
 - `/administration/history/receiving/` -> placeholder riwayat penerimaan administrasi (`apps.core.views.administration_receiving_history`)
 - `/administration/history/distribution/` -> placeholder riwayat pengeluaran administrasi (`apps.core.views.administration_distribution_history`)
@@ -61,6 +62,7 @@ Module highlights:
   - Non-Puskesmas non-superuser staff continue to use `/lplpo/` as the submitted queue only.
 - Puskesmas requests: `/puskesmas/permintaan/`, `/puskesmas/permintaan/buat/`, `/puskesmas/permintaan/<pk>/`, `/puskesmas/permintaan/<pk>/edit/`, `/puskesmas/permintaan/<pk>/delete/`, `/puskesmas/permintaan/<pk>/submit/`, `/puskesmas/permintaan/<pk>/approve/`, `/puskesmas/permintaan/<pk>/reject/`, `/puskesmas/permintaan/<pk>/reset-draft/`
 - Allocation: `/allocation/`, `/allocation/create/`, `/allocation/<pk>/`, `/allocation/<pk>/edit/`, `/allocation/<pk>/delete/`, `/allocation/<pk>/reset-to-draft/`, `/allocation/<pk>/submit/`, `/allocation/<pk>/approve/`, `/allocation/<pk>/step-back/`, `/allocation/<pk>/reject/`, `/allocation/<pk>/distributions/<dist_pk>/prepare/`, `/allocation/<pk>/distributions/<dist_pk>/deliver/`
+- Users sensitive POST actions: `/users/bulk-action/`, `/users/<pk>/toggle-active/`, `/users/<pk>/delete/`, `/users/<pk>/reset-password/`
 
 ## 3) Permission and Access Model
 
@@ -373,6 +375,12 @@ From `backend/config/settings.py`:
   2. `django.contrib.auth.backends.ModelBackend`
 - `axes.middleware.AxesMiddleware` included after standard auth/session middleware
 - `AXES_FAILURE_LIMIT = 5`, `AXES_COOLOFF_TIME = 0.5`, `AXES_RESET_ON_SUCCESS = True`
+- Sensitive POST throttling uses `django-ratelimit` with settings-backed defaults:
+  - `USER_BULK_ACTION_RATE_LIMIT = 10/m`
+  - `USER_MUTATION_RATE_LIMIT = 20/m`
+  - `USER_PASSWORD_RESET_RATE_LIMIT = 5/m`
+  - `PASSWORD_CHANGE_RATE_LIMIT = 5/m`
+- Rate-limited requests are rendered through the centralized error pipeline as HTTP `429`
 - `EMAIL_BACKEND` is environment-configurable and defaults to Django's console backend
 - `DJANGO_LOG_LEVEL` controls the Django logger level and defaults to `WARNING`
 - `DATA_UPLOAD_MAX_NUMBER_FIELDS` defaults to `10000` to support wide LPLPO and similar bulk forms

--- a/backend/apps/core/rate_limits.py
+++ b/backend/apps/core/rate_limits.py
@@ -1,0 +1,59 @@
+from django.conf import settings
+from django_ratelimit.decorators import ratelimit
+
+DEFAULT_USER_BULK_ACTION_RATE_LIMIT = "10/m"
+DEFAULT_USER_MUTATION_RATE_LIMIT = "20/m"
+DEFAULT_USER_PASSWORD_RESET_RATE_LIMIT = "5/m"
+DEFAULT_PASSWORD_CHANGE_RATE_LIMIT = "5/m"
+
+
+def _setting_rate(name, default):
+    def _rate(group, request):
+        return getattr(settings, name, default)
+
+    return _rate
+
+
+user_bulk_action_ratelimit = ratelimit(
+    key="user_or_ip",
+    method="POST",
+    rate=_setting_rate(
+        "USER_BULK_ACTION_RATE_LIMIT",
+        DEFAULT_USER_BULK_ACTION_RATE_LIMIT,
+    ),
+    block=True,
+    group="users.bulk_action",
+)
+
+user_mutation_ratelimit = ratelimit(
+    key="user_or_ip",
+    method="POST",
+    rate=_setting_rate(
+        "USER_MUTATION_RATE_LIMIT",
+        DEFAULT_USER_MUTATION_RATE_LIMIT,
+    ),
+    block=True,
+    group="users.mutation",
+)
+
+user_password_reset_ratelimit = ratelimit(
+    key="user_or_ip",
+    method="POST",
+    rate=_setting_rate(
+        "USER_PASSWORD_RESET_RATE_LIMIT",
+        DEFAULT_USER_PASSWORD_RESET_RATE_LIMIT,
+    ),
+    block=True,
+    group="users.password_reset",
+)
+
+password_change_ratelimit = ratelimit(
+    key="user_or_ip",
+    method="POST",
+    rate=_setting_rate(
+        "PASSWORD_CHANGE_RATE_LIMIT",
+        DEFAULT_PASSWORD_CHANGE_RATE_LIMIT,
+    ),
+    block=True,
+    group="auth.password_change",
+)

--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -19,6 +19,7 @@ from django.test import override_settings
 from django.template import Context, Template
 from django.urls import resolve, reverse
 from django.utils import timezone
+from django_ratelimit.exceptions import Ratelimited
 
 from apps.core.admin_mixins import ImportGuideMixin
 from apps.core.context_processors import nav_notifications
@@ -1011,6 +1012,19 @@ class ErrorHandlerTests(SimpleTestCase):
             response,
             "Hanya operator Puskesmas yang dapat membuat LPLPO.",
             status_code=403,
+        )
+
+    def test_permission_denied_handler_returns_429_for_ratelimit_exception(self):
+        request = self.factory.post("/users/bulk-action/")
+        request.user = AnonymousUser()
+
+        response = permission_denied_handler(request, Ratelimited())
+
+        self.assertEqual(response.status_code, 429)
+        self.assertContains(
+            response,
+            "Terlalu banyak percobaan pada aksi ini",
+            status_code=429,
         )
 
     def test_maintenance_mode_logs_through_core_logger(self):

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -22,6 +22,7 @@ from django.urls import reverse, reverse_lazy
 from django.views.generic.edit import UpdateView
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib import messages
+from django_ratelimit.exceptions import Ratelimited
 from apps.core.models import SystemSettings
 from apps.core.forms import SystemSettingsForm
 
@@ -116,6 +117,19 @@ def bad_request(request, exception):
 
 @requires_csrf_token
 def permission_denied_handler(request, exception):
+    if isinstance(exception, Ratelimited):
+        _log_error_event(security_logger, "warning", "rate_limited", request, 429, exception)
+        context = _build_error_context(
+            request,
+            429,
+            "Terlalu banyak percobaan pada aksi ini",
+            "Permintaan Anda untuk aksi sensitif ini melebihi batas keamanan sementara. Tunggu sejenak lalu coba lagi.",
+            "bi bi-hourglass-split",
+            "warning",
+            "Batas ini diterapkan untuk mencegah penyalahgunaan pada perubahan akun dan aksi sensitif lain. Jika Anda terus diblokir, periksa kembali apakah langkah yang sama terkirim berulang kali.",
+        )
+        return _render_error_page(request, "429.html", 429, **context)
+
     message = str(exception).strip() if exception and str(exception).strip() else (
         "Hak akses Anda tidak mencukupi untuk membuka halaman ini atau melakukan aksi yang diminta."
     )

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -1,10 +1,12 @@
 from unittest import mock
 
 from django.contrib.auth.models import Permission
+from django.core.cache import cache
 from django.contrib.messages import get_messages
 from django.core.exceptions import ValidationError
 from django.db.models import ProtectedError
 from django.test import TestCase
+from django.test import override_settings
 from django.urls import reverse
 
 from apps.items.models import Facility
@@ -37,6 +39,7 @@ class UserManagementViewsTest(TestCase):
             is_active=True,
         )
         self.client.force_login(self.admin)
+        cache.clear()
 
     def _module_scope_payload(self, scope=ModuleAccess.Scope.NONE):
         payload = {}
@@ -359,6 +362,58 @@ class UserManagementViewsTest(TestCase):
             status_code=403,
         )
 
+    @override_settings(PASSWORD_CHANGE_RATE_LIMIT="1/m")
+    def test_password_change_returns_429_when_rate_limited(self):
+        first_response = self.client.post(
+            reverse("password_change"),
+            {
+                "old_password": "secret12345",
+                "new_password1": "ChangedPass123!",
+                "new_password2": "ChangedPass123!",
+            },
+            secure=True,
+        )
+        self.assertEqual(first_response.status_code, 302)
+
+        response = self.client.post(
+            reverse("password_change"),
+            {
+                "old_password": "ChangedPass123!",
+                "new_password1": "ChangedAgain123!",
+                "new_password2": "ChangedAgain123!",
+            },
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 429)
+        self.assertContains(response, "Terlalu banyak percobaan pada aksi ini", status_code=429)
+
+    @override_settings(USER_PASSWORD_RESET_RATE_LIMIT="1/m")
+    def test_user_reset_password_returns_429_when_rate_limited(self):
+        first_response = self.client.post(
+            reverse("users:user_reset_password", args=[self.target.pk]),
+            {
+                "password1": "UpdatedPass123!",
+                "password2": "UpdatedPass123!",
+            },
+            secure=True,
+        )
+        self.assertEqual(first_response.status_code, 302)
+
+        response = self.client.post(
+            reverse("users:user_reset_password", args=[self.target.pk]),
+            {
+                "password1": "AnotherPass123!",
+                "password2": "AnotherPass123!",
+            },
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 429)
+        self.assertContains(response, "Terlalu banyak percobaan pada aksi ini", status_code=429)
+        self.target.refresh_from_db()
+        self.assertTrue(self.target.check_password("UpdatedPass123!"))
+
     def test_user_list_shows_nip(self):
         response = self.client.get(reverse("users:user_list"))
         self.assertEqual(response.status_code, 200)
@@ -414,6 +469,22 @@ class UserManagementViewsTest(TestCase):
                 "status_text": "Nonaktif",
             },
         )
+
+    @override_settings(USER_MUTATION_RATE_LIMIT="1/m")
+    def test_toggle_active_returns_429_when_rate_limited(self):
+        first_response = self.client.post(
+            reverse("users:user_toggle_active", args=[self.target.pk]),
+            secure=True,
+        )
+        self.assertEqual(first_response.status_code, 302)
+
+        response = self.client.post(
+            reverse("users:user_toggle_active", args=[self.target.pk]),
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 429)
+        self.assertContains(response, "Terlalu banyak percobaan pada aksi ini", status_code=429)
 
     def test_toggle_active_ajax_blocks_self_deactivation(self):
         response = self.client.post(
@@ -949,6 +1020,7 @@ class HybridUserAuthorizationTest(TestCase):
 
 class ProtectedUserManagementGuardsTest(TestCase):
     def setUp(self):
+        cache.clear()
         self.super_admin = User.objects.create_superuser(
             username="super_admin",
             email="super_admin@example.com",
@@ -1118,4 +1190,32 @@ class ProtectedUserManagementGuardsTest(TestCase):
                 in message
                 for message in messages
             )
+        )
+
+    @override_settings(USER_BULK_ACTION_RATE_LIMIT="1/m")
+    def test_bulk_action_returns_429_when_rate_limited(self):
+        response = self.client.post(
+            reverse("users:user_bulk_action"),
+            {
+                "action": "activate",
+                "selected_users": [self.standard_user.pk],
+            },
+            secure=True,
+        )
+        self.assertEqual(response.status_code, 302)
+
+        throttled = self.client.post(
+            reverse("users:user_bulk_action"),
+            {
+                "action": "activate",
+                "selected_users": [self.standard_user.pk],
+            },
+            secure=True,
+        )
+
+        self.assertEqual(throttled.status_code, 429)
+        self.assertContains(
+            throttled,
+            "Terlalu banyak percobaan pada aksi ini",
+            status_code=429,
         )

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -362,7 +362,7 @@ class UserManagementViewsTest(TestCase):
             status_code=403,
         )
 
-    @override_settings(PASSWORD_CHANGE_RATE_LIMIT="1/m")
+    @override_settings(PASSWORD_CHANGE_RATE_LIMIT="1/m", RATELIMIT_USE_CACHE="locmem")
     def test_password_change_returns_429_when_rate_limited(self):
         first_response = self.client.post(
             reverse("password_change"),
@@ -388,7 +388,7 @@ class UserManagementViewsTest(TestCase):
         self.assertEqual(response.status_code, 429)
         self.assertContains(response, "Terlalu banyak percobaan pada aksi ini", status_code=429)
 
-    @override_settings(USER_PASSWORD_RESET_RATE_LIMIT="1/m")
+    @override_settings(USER_PASSWORD_RESET_RATE_LIMIT="1/m", RATELIMIT_USE_CACHE="locmem")
     def test_user_reset_password_returns_429_when_rate_limited(self):
         first_response = self.client.post(
             reverse("users:user_reset_password", args=[self.target.pk]),
@@ -470,7 +470,7 @@ class UserManagementViewsTest(TestCase):
             },
         )
 
-    @override_settings(USER_MUTATION_RATE_LIMIT="1/m")
+    @override_settings(USER_MUTATION_RATE_LIMIT="1/m", RATELIMIT_USE_CACHE="locmem")
     def test_toggle_active_returns_429_when_rate_limited(self):
         first_response = self.client.post(
             reverse("users:user_toggle_active", args=[self.target.pk]),
@@ -483,6 +483,59 @@ class UserManagementViewsTest(TestCase):
             secure=True,
         )
 
+        self.assertEqual(response.status_code, 429)
+        self.assertContains(response, "Terlalu banyak percobaan pada aksi ini", status_code=429)
+
+    @override_settings(USER_MUTATION_RATE_LIMIT="1/m", RATELIMIT_USE_CACHE="locmem")
+    def test_user_create_returns_429_when_rate_limited(self):
+        payload = {
+            "username": "ratelimit_created_1",
+            "full_name": "Rate Limited Creator 1",
+            "nip": "198001012010011001",
+            "email": "rl_create1@example.com",
+            "role": User.Role.GUDANG,
+            "is_active": "on",
+            "password1": "VeryStrongPass123!",
+            "password2": "VeryStrongPass123!",
+        }
+        payload.update(self._module_scope_payload(ModuleAccess.Scope.VIEW))
+
+        first_response = self.client.post(
+            reverse("users:user_create"), payload, secure=True,
+        )
+        self.assertEqual(first_response.status_code, 302)
+
+        payload["username"] = "ratelimit_created_2"
+        payload["email"] = "rl_create2@example.com"
+        response = self.client.post(
+            reverse("users:user_create"), payload, secure=True,
+        )
+        self.assertEqual(response.status_code, 429)
+        self.assertContains(response, "Terlalu banyak percobaan pada aksi ini", status_code=429)
+
+    @override_settings(USER_MUTATION_RATE_LIMIT="1/m", RATELIMIT_USE_CACHE="locmem")
+    def test_user_update_returns_429_when_rate_limited(self):
+        payload = {
+            "username": self.target.username,
+            "full_name": "Updated Name 1",
+            "nip": "198505052010011004",
+            "email": "updated1@example.com",
+            "role": User.Role.ADMIN_UMUM,
+            "is_active": "on",
+        }
+        payload.update(self._module_scope_payload(ModuleAccess.Scope.VIEW))
+
+        first_response = self.client.post(
+            reverse("users:user_update", args=[self.target.pk]),
+            payload, secure=True,
+        )
+        self.assertEqual(first_response.status_code, 302)
+
+        payload["full_name"] = "Updated Name 2"
+        response = self.client.post(
+            reverse("users:user_update", args=[self.target.pk]),
+            payload, secure=True,
+        )
         self.assertEqual(response.status_code, 429)
         self.assertContains(response, "Terlalu banyak percobaan pada aksi ini", status_code=429)
 
@@ -1192,7 +1245,7 @@ class ProtectedUserManagementGuardsTest(TestCase):
             )
         )
 
-    @override_settings(USER_BULK_ACTION_RATE_LIMIT="1/m")
+    @override_settings(USER_BULK_ACTION_RATE_LIMIT="1/m", RATELIMIT_USE_CACHE="locmem")
     def test_bulk_action_returns_429_when_rate_limited(self):
         response = self.client.post(
             reverse("users:user_bulk_action"),

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -196,6 +196,7 @@ def user_list(request):
 
 
 @login_required
+@user_mutation_ratelimit
 def user_create(request):
     _require_user_access(
         request.user,
@@ -229,6 +230,7 @@ def user_create(request):
 
 
 @login_required
+@user_mutation_ratelimit
 def user_update(request, pk):
     _require_user_access(
         request.user,

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -2,6 +2,7 @@ import csv
 
 from django.contrib import messages
 from django.contrib.auth import update_session_auth_hash
+from django.contrib.auth import views as auth_views
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import PermissionDenied, ValidationError
@@ -10,8 +11,15 @@ from django.db.models import ProtectedError
 from django.db.models import Q
 from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.decorators import method_decorator
 
 from apps.core.csv_exports import sanitize_csv_row
+from apps.core.rate_limits import (
+    password_change_ratelimit,
+    user_bulk_action_ratelimit,
+    user_mutation_ratelimit,
+    user_password_reset_ratelimit,
+)
 
 from .access import ROLE_DEFAULT_SCOPES, has_module_permission
 from .forms import UserCreateForm, UserUpdateForm
@@ -265,6 +273,7 @@ def user_update(request, pk):
 
 
 @login_required
+@user_mutation_ratelimit
 def user_toggle_active(request, pk):
     is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
 
@@ -313,6 +322,7 @@ def user_toggle_active(request, pk):
 
 
 @login_required
+@user_mutation_ratelimit
 def user_delete(request, pk):
     _require_user_access(
         request.user,
@@ -377,6 +387,7 @@ def user_detail(request, pk):
 
 
 @login_required
+@user_bulk_action_ratelimit
 def user_bulk_action(request):
     if request.method != "POST":
         return redirect("users:user_list")
@@ -476,6 +487,7 @@ def user_bulk_action(request):
 
 
 @login_required
+@user_password_reset_ratelimit
 def user_reset_password(request, pk):
     _require_user_access(
         request.user,
@@ -516,6 +528,11 @@ def user_reset_password(request, pk):
         request, f"Password untuk {target_user.username} berhasil direset."
     )
     return redirect("users:user_update", pk=pk)
+
+
+@method_decorator(password_change_ratelimit, name="dispatch")
+class RateLimitedPasswordChangeView(auth_views.PasswordChangeView):
+    pass
 
 
 class _Echo:

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -210,7 +210,20 @@ AXES_RESET_ON_SUCCESS = True  # Reset failed count on successful login
 AXES_LOCKOUT_PARAMETERS = [["username", "ip_address"]]
 AXES_LOCKOUT_TEMPLATE = "registration/lockout.html"
 
+# ─── Cache (Redis) ────────────────────────────────────────────────────
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": os.getenv("REDIS_URL", "redis://127.0.0.1:6379/1"),
+    },
+    "locmem": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    },
+}
+
 # ─── django-ratelimit: Sensitive POST Protection ────────────────────
+RATELIMIT_USE_CACHE = "default"
+RATELIMIT_FAIL_OPEN = os.getenv("RATELIMIT_FAIL_OPEN", "True") == "True"
 USER_BULK_ACTION_RATE_LIMIT = os.getenv("USER_BULK_ACTION_RATE_LIMIT", "10/m")
 USER_MUTATION_RATE_LIMIT = os.getenv("USER_MUTATION_RATE_LIMIT", "20/m")
 USER_PASSWORD_RESET_RATE_LIMIT = os.getenv("USER_PASSWORD_RESET_RATE_LIMIT", "5/m")

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -210,6 +210,12 @@ AXES_RESET_ON_SUCCESS = True  # Reset failed count on successful login
 AXES_LOCKOUT_PARAMETERS = [["username", "ip_address"]]
 AXES_LOCKOUT_TEMPLATE = "registration/lockout.html"
 
+# ─── django-ratelimit: Sensitive POST Protection ────────────────────
+USER_BULK_ACTION_RATE_LIMIT = os.getenv("USER_BULK_ACTION_RATE_LIMIT", "10/m")
+USER_MUTATION_RATE_LIMIT = os.getenv("USER_MUTATION_RATE_LIMIT", "20/m")
+USER_PASSWORD_RESET_RATE_LIMIT = os.getenv("USER_PASSWORD_RESET_RATE_LIMIT", "5/m")
+PASSWORD_CHANGE_RATE_LIMIT = os.getenv("PASSWORD_CHANGE_RATE_LIMIT", "5/m")
+
 # ─── Production Security (enabled when DEBUG=False) ──────────────────
 if not DEBUG:
     SECURE_CONTENT_TYPE_NOSNIFF = True

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
 
+from apps.users.views import RateLimitedPasswordChangeView
 from apps.core.views import (
     SystemSettingsUpdateView,
     administration_distribution_history,
@@ -39,7 +40,7 @@ urlpatterns = [
     # Password change
     path(
         "password/change/",
-        auth_views.PasswordChangeView.as_view(
+        RateLimitedPasswordChangeView.as_view(
             template_name="registration/password_change.html",
         ),
         name="password_change",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,7 @@ django-axes==8.3.1
 django-crispy-forms==2.5
 django-filter==25.1
 django-import-export==4.4.0
+django-ratelimit==4.1.0
 gunicorn==25.1.0
 kombu==5.6.2
 openpyxl==3.1.5

--- a/backend/templates/429.html
+++ b/backend/templates/429.html
@@ -1,0 +1,9 @@
+{% extends "errors/status.html" %}
+
+{% block page_title %}429 - Terlalu Banyak Permintaan{% endblock %}
+{% block status_code %}429{% endblock %}
+{% block title %}Terlalu banyak percobaan pada aksi ini{% endblock %}
+{% block tone %}warning{% endblock %}
+{% block icon %}bi bi-hourglass-split{% endblock %}
+{% block message %}{{ message|default:"Permintaan Anda untuk aksi sensitif ini melebihi batas keamanan sementara. Tunggu sejenak lalu coba lagi." }}{% endblock %}
+{% block help_text %}{{ help_text|default:"Batas ini diterapkan untuk mencegah penyalahgunaan pada perubahan akun dan aksi sensitif lain. Jika Anda terus diblokir, periksa kembali apakah langkah yang sama terkirim berulang kali." }}{% endblock %}

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -53,6 +53,10 @@ Variabel opsional yang saat ini dibaca oleh aplikasi:
 - `DEBUG`
 - `CSRF_TRUSTED_ORIGINS`
 - `EMAIL_BACKEND`
+- `USER_BULK_ACTION_RATE_LIMIT`
+- `USER_MUTATION_RATE_LIMIT`
+- `USER_PASSWORD_RESET_RATE_LIMIT`
+- `PASSWORD_CHANGE_RATE_LIMIT`
 - `DATA_UPLOAD_MAX_NUMBER_FIELDS`
 - `FEATURE_ALLOCATION_UI_ENABLED`
 - `DJANGO_LOG_LEVEL`
@@ -63,6 +67,7 @@ Catatan:
 - `manage.py`, `config/wsgi.py`, dan `config/asgi.py` sudah default ke `config.settings`, sehingga `DJANGO_SETTINGS_MODULE` tidak perlu diubah untuk setup standar.
 - `DATA_UPLOAD_MAX_NUMBER_FIELDS` default `10000` untuk mengakomodasi form LPLPO dan form bulk serupa yang mengirim banyak field dalam satu request.
 - `FEATURE_ALLOCATION_UI_ENABLED` masih dibaca ke Django settings untuk kompatibilitas dan test override, tetapi route/UI runtime Allocation saat ini tidak bercabang pada flag tersebut; akses tetap dikendalikan oleh permission Django + `ModuleAccess`.
+- Endpoint POST sensitif memakai `django-ratelimit`; saat limit terlampaui aplikasi mengembalikan halaman `429` melalui handler error terpusat.
 
 ### 3. Jalankan infrastruktur
 


### PR DESCRIPTION
Closes #98

## Summary
- add `django-ratelimit` and central reusable rate-limit decorators for sensitive POST actions
- throttle user bulk actions, user mutations, password reset, and password change flows
- return throttled requests through the centralized error pipeline with an HTTP `429` page
- document the new settings-backed rate-limit knobs

## Verification
- `python manage.py check`
- `python manage.py test apps.core.tests.test_core.ErrorHandlerTests.test_permission_denied_handler_returns_429_for_ratelimit_exception apps.users.tests.UserManagementViewsTest.test_password_change_returns_429_when_rate_limited apps.users.tests.UserManagementViewsTest.test_user_reset_password_returns_429_when_rate_limited apps.users.tests.UserManagementViewsTest.test_toggle_active_returns_429_when_rate_limited apps.users.tests.ProtectedUserManagementGuardsTest.test_bulk_action_returns_429_when_rate_limited`
- `pip-audit --local --cache-dir C:\tmp\pip-audit-cache`

## Notes
- While verifying this issue, I logged unrelated environment-sensitive core test failures separately in #107.
- The active dev server had been running outside the repo venv; `django-ratelimit` was installed into that interpreter as well so the local server could import the new dependency immediately.