### PR TITLE
Restore locmem cache alias and close logo file in core tests

### DIFF
--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -233,6 +233,10 @@ class SystemSettingsFormTests(SimpleTestCase):
 
                 self.assertTrue(form.is_valid(), form.errors)
                 self.assertEqual(form.cleaned_data["logo"].name, "settings/logo.png")
+                if form.cleaned_data.get("logo"):
+                    form.cleaned_data["logo"].close()
+                if form.instance and form.instance.logo:
+                    form.instance.logo.close()
 
     @patch("apps.core.upload_validation.Image.open", side_effect=Image.DecompressionBombError("bomb"))
     def test_rejects_decompression_bomb_logo(self, mocked_image_open):

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -215,7 +215,10 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "healthcare-ims-cache",
-    }
+    },
+    "locmem": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    },
 }
 
 # ─── django-ratelimit: Sensitive POST Protection ────────────────────


### PR DESCRIPTION
Restores locmem cache alias to fix rate-limiting tests, and adds explicit .close() calls to logo files in core tests to prevent Windows file locks.