### PR TITLE
Harden XLSX exports against formula injection

### DIFF
--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -26,6 +26,7 @@ from apps.core.context_processors import nav_notifications
 from apps.core.csv_exports import SanitizedCSV, escape_csv_formula
 from apps.core.forms import SystemSettingsForm
 from apps.core.models import SystemSettings
+from apps.core.xlsx_exports import escape_xlsx_formula
 from apps.core.templatetags.number_format import safe_media_url
 from apps.core.views import (
     bad_request,
@@ -150,6 +151,22 @@ class CsvExportSecurityTests(SimpleTestCase):
             pass
 
         self.assertEqual(TestAdmin().get_export_formats(), [SanitizedCSV, NonCsvFormat])
+
+
+class XlsxExportSecurityTests(SimpleTestCase):
+    def test_escape_xlsx_formula_escapes_leading_whitespace_formulae(self):
+        for value in (" =SUM(A1:A2)", "\t=SUM(A1:A2)", "\r=SUM(A1:A2)", " @cmd"):
+            with self.subTest(value=value):
+                self.assertEqual(escape_xlsx_formula(value), f"'{value}")
+
+    def test_escape_xlsx_formula_does_not_double_escape_existing_apostrophe(self):
+        value = "'=SUM(A1:A2)"
+
+        self.assertEqual(escape_xlsx_formula(value), value)
+
+    def test_escape_xlsx_formula_leaves_normal_text_and_non_strings_unchanged(self):
+        self.assertEqual(escape_xlsx_formula("Paracetamol"), "Paracetamol")
+        self.assertEqual(escape_xlsx_formula(Decimal("12.50")), Decimal("12.50"))
 
 
 class SystemSettingsFormTests(SimpleTestCase):

--- a/backend/apps/core/xlsx_exports.py
+++ b/backend/apps/core/xlsx_exports.py
@@ -1,0 +1,11 @@
+FORMULA_PREFIXES = ("=", "+", "-", "@")
+
+
+def escape_xlsx_formula(value):
+    if not isinstance(value, str):
+        return value
+    if value.startswith("'"):
+        return value
+    if value.lstrip().startswith(FORMULA_PREFIXES):
+        return f"'{value}"
+    return value

--- a/backend/apps/puskesmas/exports.py
+++ b/backend/apps/puskesmas/exports.py
@@ -6,6 +6,8 @@ from openpyxl import Workbook
 from openpyxl.styles import Font, Alignment, Border, Side, PatternFill
 from openpyxl.utils import get_column_letter
 
+from apps.core.xlsx_exports import escape_xlsx_formula
+
 
 # Shared styles (mirrors reports/exports.py style)
 HEADER_FONT = Font(bold=True, size=11)
@@ -21,10 +23,14 @@ IDR_FORMAT = "#,##0.00"
 NUMBER_FORMAT = "#,##0"
 
 
+def _cell_value(value):
+    return escape_xlsx_formula(value)
+
+
 def _apply_header_row(ws, row_num, values, col_widths=None):
     """Apply header styling to a row."""
     for col_idx, val in enumerate(values, 1):
-        cell = ws.cell(row=row_num, column=col_idx, value=val)
+        cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
         cell.font = HEADER_FONT
         cell.fill = HEADER_FILL
         cell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
@@ -82,7 +88,11 @@ def export_puskesmas_penerimaan_excel(report_data, start_date, end_date, facilit
 
     # Title rows
     ws.merge_cells(f"A1:{last_col}1")
-    title_cell = ws.cell(row=1, column=1, value="RIWAYAT PENERIMAAN DARI INSTALASI FARMASI")
+    title_cell = ws.cell(
+        row=1,
+        column=1,
+        value=_cell_value("RIWAYAT PENERIMAAN DARI INSTALASI FARMASI"),
+    )
     title_cell.font = Font(bold=True, size=14)
     title_cell.alignment = Alignment(horizontal="center")
 
@@ -90,7 +100,7 @@ def export_puskesmas_penerimaan_excel(report_data, start_date, end_date, facilit
     period_cell = ws.cell(
         row=2,
         column=1,
-        value=f"Fasilitas: {facility_name} | Periode: {start_date} s/d {end_date}",
+        value=_cell_value(f"Fasilitas: {facility_name} | Periode: {start_date} s/d {end_date}"),
     )
     period_cell.font = Font(bold=True, size=11)
     period_cell.alignment = Alignment(horizontal="center")
@@ -121,7 +131,7 @@ def export_puskesmas_penerimaan_excel(report_data, start_date, end_date, facilit
             float(total_price),
         ]
         for col_idx, val in enumerate(values, 1):
-            cell = ws.cell(row=row_num, column=col_idx, value=val)
+            cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
             cell.border = THIN_BORDER
             if col_idx == 1:
                 cell.alignment = Alignment(horizontal="center")
@@ -142,7 +152,7 @@ def export_puskesmas_penerimaan_excel(report_data, start_date, end_date, facilit
         cell.font = Font(bold=True)
         cell.fill = TOTAL_FILL
         cell.border = THIN_BORDER
-    ws.cell(row=row_num, column=2, value="TOTAL").font = Font(bold=True)
+    ws.cell(row=row_num, column=2, value=_cell_value("TOTAL")).font = Font(bold=True)
     qty_cell = ws.cell(row=row_num, column=8, value=float(total_qty))
     qty_cell.number_format = NUMBER_FORMAT
     qty_cell.alignment = Alignment(horizontal="right")
@@ -188,7 +198,11 @@ def export_puskesmas_pemakaian_excel(report_data, year, month_label, facility_na
 
     # Title rows
     ws.merge_cells(f"A1:{last_col}1")
-    title_cell = ws.cell(row=1, column=1, value="RIWAYAT PEMAKAIAN PUSKESMAS (DARI DATA LPLPO)")
+    title_cell = ws.cell(
+        row=1,
+        column=1,
+        value=_cell_value("RIWAYAT PEMAKAIAN PUSKESMAS (DARI DATA LPLPO)"),
+    )
     title_cell.font = Font(bold=True, size=14)
     title_cell.alignment = Alignment(horizontal="center")
 
@@ -196,7 +210,7 @@ def export_puskesmas_pemakaian_excel(report_data, year, month_label, facility_na
     period_cell = ws.cell(
         row=2,
         column=1,
-        value=f"Fasilitas: {facility_name} | Tahun: {year} | Bulan: {month_label}",
+        value=_cell_value(f"Fasilitas: {facility_name} | Tahun: {year} | Bulan: {month_label}"),
     )
     period_cell.font = Font(bold=True, size=11)
     period_cell.alignment = Alignment(horizontal="center")
@@ -217,7 +231,7 @@ def export_puskesmas_pemakaian_excel(report_data, year, month_label, facility_na
             int(row.get("permintaan_jumlah", 0) or 0),
         ]
         for col_idx, val in enumerate(values, 1):
-            cell = ws.cell(row=row_num, column=col_idx, value=val)
+            cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
             cell.border = THIN_BORDER
             if col_idx == 1:
                 cell.alignment = Alignment(horizontal="center")
@@ -264,7 +278,7 @@ def export_puskesmas_persediaan_excel(report_data, year, period_label, facility_
     title_cell = ws.cell(
         row=1,
         column=1,
-        value="RINCIAN LAPORAN PERSEDIAAN OBAT DAN PERBEKALAN KESEHATAN — PUSKESMAS",
+        value=_cell_value("RINCIAN LAPORAN PERSEDIAAN OBAT DAN PERBEKALAN KESEHATAN — PUSKESMAS"),
     )
     title_cell.font = Font(bold=True, size=14)
     title_cell.alignment = Alignment(horizontal="center")
@@ -273,7 +287,7 @@ def export_puskesmas_persediaan_excel(report_data, year, period_label, facility_
     period_cell = ws.cell(
         row=2,
         column=1,
-        value=f"Fasilitas: {facility_name} | Tahun: {year} | Periode: {period_label}",
+        value=_cell_value(f"Fasilitas: {facility_name} | Tahun: {year} | Periode: {period_label}"),
     )
     period_cell.font = Font(bold=True, size=11)
     period_cell.alignment = Alignment(horizontal="center")
@@ -290,7 +304,7 @@ def export_puskesmas_persediaan_excel(report_data, year, period_label, facility_
             int(row.get("stock_keseluruhan", 0) or 0),
         ]
         for col_idx, val in enumerate(values, 1):
-            cell = ws.cell(row=row_num, column=col_idx, value=val)
+            cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
             cell.border = THIN_BORDER
             if col_idx == 1:
                 cell.alignment = Alignment(horizontal="center")
@@ -335,7 +349,7 @@ def export_puskesmas_rekap_persediaan_excel(rekap_data, totals, year, period_lab
     ws.merge_cells(f"A1:{last_col}1")
     title_cell = ws.cell(
         row=1, column=1,
-        value="REKAPITULASI LAPORAN PERSEDIAAN OBAT DAN PERBEKALAN KESEHATAN — PUSKESMAS",
+        value=_cell_value("REKAPITULASI LAPORAN PERSEDIAAN OBAT DAN PERBEKALAN KESEHATAN — PUSKESMAS"),
     )
     title_cell.font = Font(bold=True, size=14)
     title_cell.alignment = Alignment(horizontal="center")
@@ -343,7 +357,7 @@ def export_puskesmas_rekap_persediaan_excel(rekap_data, totals, year, period_lab
     ws.merge_cells(f"A2:{last_col}2")
     period_cell = ws.cell(
         row=2, column=1,
-        value=f"Fasilitas: {facility_name} | Tahun: {year} | Periode: {period_label}",
+        value=_cell_value(f"Fasilitas: {facility_name} | Tahun: {year} | Periode: {period_label}"),
     )
     period_cell.font = Font(bold=True, size=11)
     period_cell.alignment = Alignment(horizontal="center")
@@ -362,7 +376,7 @@ def export_puskesmas_rekap_persediaan_excel(rekap_data, totals, year, period_lab
             float(Decimal(str(row.get("saldo_akhir", 0) or 0))),
         ]
         for col_idx, val in enumerate(values, 1):
-            cell = ws.cell(row=row_num, column=col_idx, value=val)
+            cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
             cell.border = THIN_BORDER
             if col_idx == 1:
                 cell.alignment = Alignment(horizontal="center")
@@ -377,7 +391,7 @@ def export_puskesmas_rekap_persediaan_excel(rekap_data, totals, year, period_lab
         cell.font = Font(bold=True)
         cell.fill = TOTAL_FILL
         cell.border = THIN_BORDER
-    ws.cell(row=row_num, column=2, value="TOTAL").font = Font(bold=True)
+    ws.cell(row=row_num, column=2, value=_cell_value("TOTAL")).font = Font(bold=True)
     total_columns = [
         (3, "saldo_awal", IDR_FORMAT, float),
         (4, "nilai_terima", IDR_FORMAT, float),

--- a/backend/apps/puskesmas/tests.py
+++ b/backend/apps/puskesmas/tests.py
@@ -8,6 +8,7 @@ from openpyxl import load_workbook
 from apps.core.tests.mixins import SecureClientDefaultsMixin
 from apps.distribution.models import Distribution
 from apps.items.models import Category, Facility, Item, Unit
+from apps.puskesmas.exports import export_puskesmas_penerimaan_excel
 from apps.puskesmas.forms import PuskesmasRequestForm, PuskesmasRequestItemForm
 from apps.puskesmas.models import PuskesmasRequest, PuskesmasRequestItem
 from apps.users.access import ensure_default_module_access
@@ -1185,4 +1186,43 @@ class PuskesmasReportViewTests(SecureClientDefaultsMixin, TestCase):
 		)
 		self.assertEqual(sheet.cell(row=5, column=2).value, self.category.name)
 		self.assertEqual(sheet.cell(row=6, column=2).value, "TOTAL")
+
+	def test_penerimaan_excel_neutralizes_formula_prefixed_text_and_keeps_numeric_cells(self):
+		response = export_puskesmas_penerimaan_excel(
+			[
+				{
+					"distributed_date": None,
+					"document_number": "=DIST-001",
+					"distribution_type_label": "+LPLPO",
+					"nama_barang": "@Amoxicillin 500 mg",
+					"satuan": "-Tablet",
+					"issued_batch_lot": "=BATCH-01",
+					"quantity": Decimal("5"),
+					"issued_unit_price": Decimal("2500"),
+				}
+			],
+			"2026-03-01",
+			"2026-03-31",
+			"=Puskesmas Formula",
+		)
+
+		workbook = load_workbook(BytesIO(response.content))
+		sheet = workbook.active
+
+		self.assertEqual(
+			sheet["A2"].value,
+			"Fasilitas: =Puskesmas Formula | Periode: 2026-03-01 s/d 2026-03-31",
+		)
+		self.assertEqual(sheet["C5"].value, "'=DIST-001")
+		self.assertEqual(sheet["D5"].value, "'+LPLPO")
+		self.assertEqual(sheet["E5"].value, "'@Amoxicillin 500 mg")
+		self.assertEqual(sheet["F5"].value, "'-Tablet")
+		self.assertEqual(sheet["G5"].value, "'=BATCH-01")
+		self.assertEqual(sheet["A2"].data_type, "s")
+		self.assertEqual(sheet["H5"].value, 5)
+		self.assertEqual(sheet["I5"].value, 2500)
+		self.assertEqual(sheet["J5"].value, 12500)
+		self.assertEqual(sheet["H5"].data_type, "n")
+		self.assertEqual(sheet["I5"].data_type, "n")
+		self.assertEqual(sheet["J5"].data_type, "n")
 

--- a/backend/apps/reports/exports.py
+++ b/backend/apps/reports/exports.py
@@ -5,6 +5,8 @@ from openpyxl import Workbook
 from openpyxl.styles import Font, Alignment, Border, Side, PatternFill, numbers
 from openpyxl.utils import get_column_letter
 
+from apps.core.xlsx_exports import escape_xlsx_formula
+
 
 # Shared styles
 HEADER_FONT = Font(bold=True, size=11)
@@ -21,10 +23,14 @@ THIN_BORDER = Border(
 IDR_FORMAT = '#,##0.00'
 
 
+def _cell_value(value):
+    return escape_xlsx_formula(value)
+
+
 def _apply_header_row(ws, row_num, values, col_widths=None):
     """Apply header styling to a row."""
     for col_idx, val in enumerate(values, 1):
-        cell = ws.cell(row=row_num, column=col_idx, value=val)
+        cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
         cell.font = HEADER_FONT
         cell.fill = HEADER_FILL
         cell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
@@ -58,12 +64,20 @@ def export_rincian_excel(report_data, start_date, end_date):
 
     # Title rows
     ws.merge_cells("A1:L1")
-    title_cell = ws.cell(row=1, column=1, value="LAPORAN PERSEDIAAN OBAT DAN PERBEKALAN KESEHATAN (RINCIAN)")
+    title_cell = ws.cell(
+        row=1,
+        column=1,
+        value=_cell_value("LAPORAN PERSEDIAAN OBAT DAN PERBEKALAN KESEHATAN (RINCIAN)"),
+    )
     title_cell.font = Font(bold=True, size=14)
     title_cell.alignment = Alignment(horizontal="center")
 
     ws.merge_cells("A2:L2")
-    period_cell = ws.cell(row=2, column=1, value=f"Periode: {start_date} s/d {end_date}")
+    period_cell = ws.cell(
+        row=2,
+        column=1,
+        value=_cell_value(f"Periode: {start_date} s/d {end_date}"),
+    )
     period_cell.font = Font(bold=True, size=11)
     period_cell.alignment = Alignment(horizontal="center")
 
@@ -87,7 +101,11 @@ def export_rincian_excel(report_data, start_date, end_date):
             item_counter = 0
             # Category row
             ws.merge_cells(start_row=row_num, start_column=1, end_row=row_num, end_column=12)
-            cat_cell = ws.cell(row=row_num, column=1, value=cat or "KATEGORI TIDAK DIKETAHUI")
+            cat_cell = ws.cell(
+                row=row_num,
+                column=1,
+                value=_cell_value(cat or "KATEGORI TIDAK DIKETAHUI"),
+            )
             cat_cell.font = Font(bold=True, size=11)
             cat_cell.fill = CATEGORY_FILL
             _apply_border(ws, row_num, 12)
@@ -115,7 +133,7 @@ def export_rincian_excel(report_data, start_date, end_date):
             float(row.get('ending_stock', 0)),
         ]
         for col_idx, val in enumerate(values, 1):
-            cell = ws.cell(row=row_num, column=col_idx, value=val)
+            cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
             cell.border = THIN_BORDER
             if col_idx >= 7:  # Numeric columns
                 cell.number_format = IDR_FORMAT
@@ -136,12 +154,20 @@ def export_rekap_excel(rekap_data, grand_totals, start_date, end_date):
 
     # Title rows
     ws.merge_cells("A1:G1")
-    title_cell = ws.cell(row=1, column=1, value="LAPORAN PERSEDIAAN OBAT DAN PERBEKALAN KESEHATAN (REKAP)")
+    title_cell = ws.cell(
+        row=1,
+        column=1,
+        value=_cell_value("LAPORAN PERSEDIAAN OBAT DAN PERBEKALAN KESEHATAN (REKAP)"),
+    )
     title_cell.font = Font(bold=True, size=14)
     title_cell.alignment = Alignment(horizontal="center")
 
     ws.merge_cells("A2:G2")
-    period_cell = ws.cell(row=2, column=1, value=f"Periode: {start_date} s/d {end_date}")
+    period_cell = ws.cell(
+        row=2,
+        column=1,
+        value=_cell_value(f"Periode: {start_date} s/d {end_date}"),
+    )
     period_cell.font = Font(bold=True, size=11)
     period_cell.alignment = Alignment(horizontal="center")
 
@@ -166,7 +192,7 @@ def export_rekap_excel(rekap_data, grand_totals, start_date, end_date):
             float(sd_group['subtotal_saldo_akhir']),
         ]
         for col_idx, val in enumerate(sd_values, 1):
-            cell = ws.cell(row=row_num, column=col_idx, value=val)
+            cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
             cell.font = Font(bold=True)
             cell.fill = SD_HEADER_FILL
             cell.border = THIN_BORDER
@@ -187,7 +213,7 @@ def export_rekap_excel(rekap_data, grand_totals, start_date, end_date):
                 float(cat['saldo_akhir']),
             ]
             for col_idx, val in enumerate(cat_values, 1):
-                cell = ws.cell(row=row_num, column=col_idx, value=val)
+                cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
                 cell.border = THIN_BORDER
                 if col_idx >= 3:
                     cell.number_format = IDR_FORMAT
@@ -207,7 +233,7 @@ def export_rekap_excel(rekap_data, grand_totals, start_date, end_date):
         float(grand_totals.get('saldo_akhir', 0)),
     ]
     for col_idx, val in enumerate(total_values, 1):
-        cell = ws.cell(row=row_num, column=col_idx, value=val)
+        cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
         cell.font = Font(bold=True)
         cell.fill = TOTAL_FILL
         cell.border = THIN_BORDER
@@ -231,7 +257,7 @@ def export_numbering_history_excel(history_rows, year, distribution_type_label):
     title_cell = ws.cell(
         row=1,
         column=1,
-        value="LAPORAN RIWAYAT PENOMORAN DOKUMEN",
+        value=_cell_value("LAPORAN RIWAYAT PENOMORAN DOKUMEN"),
     )
     title_cell.font = Font(bold=True, size=14)
     title_cell.alignment = Alignment(horizontal="center")
@@ -240,7 +266,7 @@ def export_numbering_history_excel(history_rows, year, distribution_type_label):
     filter_text = f"Tahun: {year}"
     if distribution_type_label:
         filter_text += f" | Jenis Dokumen: {distribution_type_label}"
-    period_cell = ws.cell(row=2, column=1, value=filter_text)
+    period_cell = ws.cell(row=2, column=1, value=_cell_value(filter_text))
     period_cell.font = Font(bold=True, size=11)
     period_cell.alignment = Alignment(horizontal="center")
 
@@ -270,7 +296,7 @@ def export_numbering_history_excel(history_rows, year, distribution_type_label):
             row.get("item_count", 0),
         ]
         for col_idx, val in enumerate(values, 1):
-            cell = ws.cell(row=row_num, column=col_idx, value=val)
+            cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
             cell.border = THIN_BORDER
             if col_idx in (1, 8):
                 cell.alignment = Alignment(horizontal="center")
@@ -292,12 +318,16 @@ def _export_penerimaan_excel(report_data, start_date, end_date, title, filename_
 
     # Title rows
     ws.merge_cells(f"A1:{last_col}1")
-    title_cell = ws.cell(row=1, column=1, value=title)
+    title_cell = ws.cell(row=1, column=1, value=_cell_value(title))
     title_cell.font = Font(bold=True, size=14)
     title_cell.alignment = Alignment(horizontal="center")
 
     ws.merge_cells(f"A2:{last_col}2")
-    period_cell = ws.cell(row=2, column=1, value=f"Periode: {start_date} s/d {end_date}")
+    period_cell = ws.cell(
+        row=2,
+        column=1,
+        value=_cell_value(f"Periode: {start_date} s/d {end_date}"),
+    )
     period_cell.font = Font(bold=True, size=11)
     period_cell.alignment = Alignment(horizontal="center")
 
@@ -310,7 +340,7 @@ def _export_penerimaan_excel(report_data, start_date, end_date, title, filename_
     for idx, row in enumerate(report_data, 1):
         values = row_builder(idx, row)
         for col_idx, val in enumerate(values, 1):
-            cell = ws.cell(row=row_num, column=col_idx, value=val)
+            cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
             cell.border = THIN_BORDER
             # Last two cols are numeric (qty + total Rp), unit_price is third-to-last
             if col_idx >= col_count - 2:
@@ -328,8 +358,8 @@ def _export_penerimaan_excel(report_data, start_date, end_date, title, filename_
         cell.font = Font(bold=True)
         cell.fill = TOTAL_FILL
         cell.border = THIN_BORDER
-    ws.cell(row=row_num, column=1, value="").font = Font(bold=True)
-    ws.cell(row=row_num, column=2, value="TOTAL").font = Font(bold=True)
+    ws.cell(row=row_num, column=1, value=_cell_value("")).font = Font(bold=True)
+    ws.cell(row=row_num, column=2, value=_cell_value("TOTAL")).font = Font(bold=True)
     qty_cell = ws.cell(row=row_num, column=col_count - 1, value=total_qty)
     qty_cell.number_format = IDR_FORMAT
     qty_cell.alignment = Alignment(horizontal="right")
@@ -468,16 +498,23 @@ def export_pengeluaran_excel(
 
     # Title rows
     ws.merge_cells(f"A1:{last_col}1")
-    title_cell = ws.cell(row=1, column=1, value="LAPORAN PENGELUARAN / DISTRIBUSI")
+    title_cell = ws.cell(
+        row=1,
+        column=1,
+        value=_cell_value("LAPORAN PENGELUARAN / DISTRIBUSI"),
+    )
     title_cell.font = Font(bold=True, size=14)
     title_cell.alignment = Alignment(horizontal="center")
 
     ws.merge_cells(f"A2:{last_col}2")
-    period_cell = ws.cell(row=2, column=1,
-                          value=(
-                              f"Periode: {start_date} s/d {end_date} | "
-                              f"Fasilitas: {facility_name} | Jenis Distribusi: {distribution_type_label}"
-                          ))
+    period_cell = ws.cell(
+        row=2,
+        column=1,
+        value=_cell_value(
+            f"Periode: {start_date} s/d {end_date} | "
+            f"Fasilitas: {facility_name} | Jenis Distribusi: {distribution_type_label}"
+        ),
+    )
     period_cell.font = Font(bold=True, size=11)
     period_cell.alignment = Alignment(horizontal="center")
 
@@ -507,7 +544,7 @@ def export_pengeluaran_excel(
             float(row.get('total_price', 0)),
         ]
         for col_idx, val in enumerate(values, 1):
-            cell = ws.cell(row=row_num, column=col_idx, value=val)
+            cell = ws.cell(row=row_num, column=col_idx, value=_cell_value(val))
             cell.border = THIN_BORDER
             if col_idx >= col_count - 2:
                 cell.number_format = IDR_FORMAT
@@ -524,7 +561,7 @@ def export_pengeluaran_excel(
         cell.font = Font(bold=True)
         cell.fill = TOTAL_FILL
         cell.border = THIN_BORDER
-    ws.cell(row=row_num, column=2, value="TOTAL").font = Font(bold=True)
+    ws.cell(row=row_num, column=2, value=_cell_value("TOTAL")).font = Font(bold=True)
     qty_cell = ws.cell(row=row_num, column=col_count - 1, value=total_qty)
     qty_cell.number_format = IDR_FORMAT
     qty_cell.alignment = Alignment(horizontal="right")

--- a/backend/apps/reports/tests.py
+++ b/backend/apps/reports/tests.py
@@ -1,8 +1,12 @@
+from io import BytesIO
+
 from django.test import TestCase
 from django.urls import reverse
+from openpyxl import load_workbook
 
 from apps.distribution.models import Distribution
 from apps.items.models import Category, Facility, FundingSource, Item, Location, Unit
+from apps.reports.exports import export_numbering_history_excel, export_pengeluaran_excel
 from apps.stock.models import Stock
 from apps.users.models import User
 
@@ -105,6 +109,36 @@ class NumberingHistoryReportTests(TestCase):
 			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 		)
 		self.assertIn('Riwayat_Penomoran_2026.xlsx', response['Content-Disposition'])
+
+	def test_numbering_history_excel_neutralizes_formula_prefixed_strings(self):
+		response = export_numbering_history_excel(
+			[
+				{
+					"document_number": "=DOC-001",
+					"distribution_type": "+LPLPO",
+					"status": "@Draft",
+					"facility_name": "-Facility",
+					"source_label": "=LPLPO",
+					"source_document_number": "=SRC-001",
+					"created_at": None,
+					"item_count": 1,
+				}
+			],
+			2026,
+			"=Semua Dokumen",
+		)
+
+		workbook = load_workbook(BytesIO(response.content))
+		sheet = workbook.active
+
+		self.assertEqual(sheet["A2"].value, "Tahun: 2026 | Jenis Dokumen: =Semua Dokumen")
+		self.assertEqual(sheet["B5"].value, "'=DOC-001")
+		self.assertEqual(sheet["C5"].value, "'+LPLPO")
+		self.assertEqual(sheet["D5"].value, "'@Draft")
+		self.assertEqual(sheet["E5"].value, "'-Facility")
+		self.assertEqual(sheet["F5"].value, "'=LPLPO: =SRC-001")
+		self.assertEqual(sheet["A2"].data_type, "s")
+		self.assertEqual(sheet["B5"].data_type, "s")
 
 
 class PengeluaranReportTests(TestCase):
@@ -306,3 +340,46 @@ class PengeluaranReportTests(TestCase):
 		self.assertIn('distribution_type=ALLOCATION', allocation_tab['url'])
 		self.assertIn('start_date=2026-04-01', allocation_tab['url'])
 		self.assertIn('end_date=2026-04-30', allocation_tab['url'])
+
+	def test_pengeluaran_excel_neutralizes_formula_prefixed_text_and_keeps_numeric_cells(self):
+		response = export_pengeluaran_excel(
+			[
+				{
+					"document_number": "=DOC-OUT-1",
+					"facility_name": "+Puskesmas Formula",
+					"nama_barang": "@Amoxicillin",
+					"satuan": "-Botol",
+					"batch_lot": "=BATCH-01",
+					"expiry_date": None,
+					"sumber_dana": "=DAU",
+					"unit_price": 2500,
+					"quantity": 5,
+					"total_price": 12500,
+				}
+			],
+			"2026-04-01",
+			"2026-04-30",
+			facility_name="=Semua Fasilitas",
+			distribution_type_label="+Semua Distribusi",
+		)
+
+		workbook = load_workbook(BytesIO(response.content))
+		sheet = workbook.active
+
+		self.assertEqual(
+			sheet["A2"].value,
+			"Periode: 2026-04-01 s/d 2026-04-30 | Fasilitas: =Semua Fasilitas | Jenis Distribusi: +Semua Distribusi",
+		)
+		self.assertEqual(sheet["B5"].value, "'=DOC-OUT-1")
+		self.assertEqual(sheet["C5"].value, "'+Puskesmas Formula")
+		self.assertEqual(sheet["D5"].value, "'@Amoxicillin")
+		self.assertEqual(sheet["E5"].value, "'-Botol")
+		self.assertEqual(sheet["F5"].value, "'=BATCH-01")
+		self.assertEqual(sheet["H5"].value, "'=DAU")
+		self.assertEqual(sheet["A2"].data_type, "s")
+		self.assertEqual(sheet["I5"].value, 2500)
+		self.assertEqual(sheet["J5"].value, 5)
+		self.assertEqual(sheet["K5"].value, 12500)
+		self.assertEqual(sheet["I5"].data_type, "n")
+		self.assertEqual(sheet["J5"].data_type, "n")
+		self.assertEqual(sheet["K5"].data_type, "n")


### PR DESCRIPTION
## Summary
- add a shared XLSX formula-neutralization helper in `apps.core`
- sanitize all string cells written by `reports` and `puskesmas` workbook exports
- add regression tests to verify dangerous strings are neutralized while numeric workbook cells remain numeric

## Scope
This PR implements only issue #117 slice 1.

Included:
- workbook export hardening for `backend/apps/reports/exports.py`
- workbook export hardening for `backend/apps/puskesmas/exports.py`
- helper coverage in `backend/apps/core/tests/test_core.py`
- direct workbook regression coverage in `backend/apps/reports/tests.py` and `backend/apps/puskesmas/tests.py`

Not included:
- media/attachment access changes
- throttling changes
- report authorization scope changes
- route, model, migration, or settings changes

## Implementation Notes
- Strings whose left-stripped value begins with `=`, `+`, `-`, or `@` are prefixed with a single apostrophe before being written to XLSX cells.
- Existing apostrophe-prefixed values are left unchanged.
- Non-string values are passed through untouched so quantity and price cells continue to be written as numeric cells.
- Title/filter summary rows are sanitized too, not only row data.

## Verification
Targeted tests run:
- `./scripts/run-django-test.ps1 -Target apps.core.tests.test_core.XlsxExportSecurityTests`
- `./scripts/run-django-test.ps1 -Target apps.reports.tests.NumberingHistoryReportTests.test_numbering_history_excel_neutralizes_formula_prefixed_strings`
- `./scripts/run-django-test.ps1 -Target apps.reports.tests.PengeluaranReportTests.test_pengeluaran_excel_neutralizes_formula_prefixed_text_and_keeps_numeric_cells`
- `./scripts/run-django-test.ps1 -Target apps.puskesmas.tests.PuskesmasReportViewTests.test_penerimaan_excel_neutralizes_formula_prefixed_text_and_keeps_numeric_cells`

Notes:
- broader `apps.core.tests.test_core` contains unrelated pre-existing temp-directory and environment failures on this machine
- broader `apps.reports.tests` currently returns `301` in several existing route tests unrelated to this export hardening slice
- one parallel test invocation also hit an existing test database name collision, so final verification was run on the targeted tests above

Closes #117