### PR TITLE
Tighten puskesmas and LPLPO facility isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,8 @@ If documentation conflicts with code, code is authoritative until docs are corre
 - `recall`: supplier return workflow
 - `expired`: expired/disposal workflow and alerts page
 - `stock_opname`: physical counting workflow
-- `puskesmas`: ad-hoc requests from Puskesmas
-- `lplpo`: monthly reporting and stock requests from Puskesmas
+- `puskesmas`: ad-hoc requests from Puskesmas. All operational and report-facing surfaces now require a linked `user.facility` for every non-superuser account and enforce same-facility object access.
+- `lplpo`: monthly reporting and stock requests from Puskesmas. All non-superuser queue, detail, print, verification, review, reject, finalize, and prefill surfaces now require a linked `user.facility` and are scoped to that facility.
 - `reports`: report index with rekap, hibah receiving, procurement, expiry, outbound reporting views, and document numbering history for LPLPO/Special Request distributions. The combined outbound report remains on `/reports/pengeluaran/`, while the distribution module owns dedicated route-based report variants at `/distribution/report/`, `/distribution/report/special-requests/`, `/distribution/report/allocation/`, and `/distribution/report/lplpo/`.
   Puskesmas-side `Rekap Laporan Persediaan` also carries an LPLPO-derived asset valuation dimension summarized per kategori from per-line `harga_satuan`.
   Puskesmas-side `Rincian` and `Rekap Laporan Persediaan` filters use yearly, triwulan, and semester periods rather than a raw month selector.
@@ -90,7 +90,8 @@ Default scopes per role are defined in `backend/apps/users/access.py`.
 ### Specialized Roles (e.g. OPERATOR PUSKESMAS)
 
 - `OPERATOR PUSKESMAS` role uses `facility` matching. Views in `puskesmas` and `lplpo` enforce strict facility isolation so that operators from one facility cannot read/write another facility's documents.
-- Super Admin (`is_superuser` / role `ADMIN`) is exempt from facility scoping in `lplpo` and may create, edit, submit, and delete LPLPO across all Puskesmas facilities.
+- Every non-superuser account using `puskesmas` or `lplpo` operational surfaces must have a linked `facility`; otherwise the request is denied with `403`.
+- Super Admin (`is_superuser` / role `ADMIN`) is the only role exempt from `puskesmas` and `lplpo` facility scoping and may cross facility boundaries on those modules.
 - Puskesmas report routes require `reports.view_reports` (or REPORTS module-scope VIEW fallback). Superusers may query all facilities; any non-superuser user is forced to their linked `facility` on those report querysets and receives `403` when no facility is linked.
 
 ## Workflow and Data Mutation Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog and follows Semantic Versioning (`MAJOR.
 
 ### Added
 
+- Security hardening: tightened `puskesmas` and `lplpo` facility tenancy so only superusers may cross facility boundaries; all other operational queue/detail/print/review/prefill surfaces now require a linked facility and return `403` on mismatch or missing linkage.
 - Distribution: added a dedicated manual LPLPO create route at `/distribution/lplpo/create/` so Instalasi Farmasi can issue LPLPO-bucket distributions during mid-year rollout or catch-up without forcing immediate January-to-current Puskesmas backfill.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Solusi ini membantu proses inventaris berjalan lebih konsisten melalui alur doku
 - `recall`: alur retur ke supplier dari draft sampai selesai.
 - `expired`: alur penanganan barang kedaluwarsa dari draft sampai disposal, termasuk halaman alert kedaluwarsa.
 - `stock_opname`: proses hitung fisik dan cetak laporan selisih.
-- `puskesmas`: pengajuan permintaan barang ad-hoc dari unit Puskesmas.
+- `puskesmas`: pengajuan permintaan barang ad-hoc dari unit Puskesmas. Seluruh surface operasional modul ini sekarang mewajibkan `facility` pada akun untuk semua non-superuser dan selalu membatasi akses objek ke fasilitas akun tersebut.
 - `lplpo`: pelaporan pemakaian dan permintaan rutin bulanan dari Puskesmas, termasuk pelacakan `harga_satuan` per baris untuk valuasi aset pada rekap persediaan.
-  Super Admin dapat mengelola LPLPO lintas fasilitas, sementara operator Puskesmas tetap dibatasi ke fasilitasnya sendiri.
+  Super Admin dapat mengelola LPLPO lintas fasilitas, sedangkan semua pengguna non-superuser kini wajib punya `facility` terhubung dan selalu dibatasi ke fasilitasnya sendiri pada queue, detail, print, verifikasi, review, reject, finalize, dan prefill.
 - Laporan Puskesmas (`Riwayat Penerimaan`, `Riwayat Pemakaian`, `Rincian Persediaan`, dan `Rekap Persediaan`) kini hanya mendukung cakupan lintas fasilitas untuk superuser. Pengguna non-superuser selalu dipaksa ke `facility` akun mereka sendiri dan akan ditolak bila akun belum terhubung ke fasilitas.
 - `users`: manajemen pengguna dan pengaturan cakupan akses modul.
 

--- a/SYSTEM_MODEL.md
+++ b/SYSTEM_MODEL.md
@@ -2,7 +2,7 @@
 
 Canonical reference for current schema, route topology, permission model, and stock mutation behavior.
 
-Last verified: 2026-06-08
+Last verified: 2026-06-09
 Verification sources: `backend/apps/*/models.py`, `backend/config/urls.py`, `backend/apps/*/urls.py`, `backend/apps/core/decorators.py`, `backend/apps/users/access.py`, `backend/config/settings.py`, `backend/apps/receiving/admin.py`, `backend/apps/distribution/services.py`, `backend/apps/allocation/services.py`, `backend/apps/stock/views.py`, `backend/apps/lplpo/models.py`, `backend/apps/core/rate_limits.py`, `backend/apps/users/views.py`
 
 ## 1) Domain Overview
@@ -59,8 +59,10 @@ Module highlights:
   - `review/` is the active stock-planning checkpoint: PIC review saves `pemberian_*`, stamps review audit fields, and atomically creates the linked draft LPLPO distribution.
   - `finalize/` remains only as a compatibility endpoint for older rows still stuck in `REVIEWED` from the previous workflow.
   - Super Admin sees all statuses on `/lplpo/` and can perform create/edit/submit/delete across facilities.
+  - Every non-superuser request to `/lplpo/`, detail/print pages, review/finalize actions, and the prefill endpoint must have a linked `user.facility` and is forced to that facility's data.
   - Non-Puskesmas non-superuser staff continue to use `/lplpo/` as the submitted queue only.
 - Puskesmas requests: `/puskesmas/permintaan/`, `/puskesmas/permintaan/buat/`, `/puskesmas/permintaan/<pk>/`, `/puskesmas/permintaan/<pk>/edit/`, `/puskesmas/permintaan/<pk>/delete/`, `/puskesmas/permintaan/<pk>/submit/`, `/puskesmas/permintaan/<pk>/approve/`, `/puskesmas/permintaan/<pk>/reject/`, `/puskesmas/permintaan/<pk>/reset-draft/`
+  - Superusers may work across facilities, while every non-superuser request is forced to the linked `user.facility` and receives `403` when no facility is linked or the object belongs to another facility.
   - Report routes `/puskesmas/laporan/penerimaan/`, `/puskesmas/laporan/pemakaian/`, `/puskesmas/laporan/persediaan/`, and `/puskesmas/laporan/rekap-persediaan/` are all-facility only for superusers; every non-superuser request is forced to the request user's linked facility.
 - Allocation: `/allocation/`, `/allocation/create/`, `/allocation/<pk>/`, `/allocation/<pk>/edit/`, `/allocation/<pk>/delete/`, `/allocation/<pk>/reset-to-draft/`, `/allocation/<pk>/submit/`, `/allocation/<pk>/approve/`, `/allocation/<pk>/step-back/`, `/allocation/<pk>/reject/`, `/allocation/<pk>/distributions/<dist_pk>/prepare/`, `/allocation/<pk>/distributions/<dist_pk>/deliver/`
 - Users sensitive POST actions: `/users/bulk-action/`, `/users/<pk>/toggle-active/`, `/users/<pk>/delete/`, `/users/<pk>/reset-password/`
@@ -85,7 +87,7 @@ Permission denials are expected to raise `PermissionDenied` so the centralized 4
 Special rule:
 
 - For `users.*` permissions, non-view actions require `MANAGE` scope.
-- `lplpo` facility isolation applies only to `PUSKESMAS` users; Super Admin users (`is_superuser`) can access and mutate LPLPO across all facilities.
+- `lplpo` and `puskesmas` facility isolation now applies to every non-superuser account; Super Admin users (`is_superuser`) are the only users who can access and mutate records across all facilities.
 - Puskesmas report routes require `reports.view_reports` (or REPORTS module-scope VIEW fallback), and their facility isolation is stricter than the general module access model: superusers may query all facilities, while every non-superuser must have a linked `facility` and is scoped to it.
 
 Role default scopes are seeded in `backend/apps/users/access.py` via `ROLE_DEFAULT_SCOPES`.

--- a/backend/apps/lplpo/tests.py
+++ b/backend/apps/lplpo/tests.py
@@ -78,6 +78,18 @@ class LPLPOTestCase(SecureClientDefaultsMixin, TestCase):
 			username="gudang",
 			password="TestPassword123!",
 			role=User.Role.GUDANG,
+			facility=cls.facility,
+		)
+		cls.other_gudang_user = User.objects.create_user(
+			username="gudang_other_facility",
+			password="TestPassword123!",
+			role=User.Role.GUDANG,
+			facility=cls.other_facility,
+		)
+		cls.gudang_without_facility = User.objects.create_user(
+			username="gudang_tanpa_fasilitas",
+			password="TestPassword123!",
+			role=User.Role.GUDANG,
 		)
 		cls.staff_user = User.objects.create_superuser(
 			username="staff",
@@ -94,6 +106,8 @@ class LPLPOTestCase(SecureClientDefaultsMixin, TestCase):
 			(cls.puskesmas_user, ModuleAccess.Scope.OPERATE),
 			(cls.other_puskesmas_user, ModuleAccess.Scope.OPERATE),
 			(cls.gudang_user, ModuleAccess.Scope.OPERATE),
+			(cls.other_gudang_user, ModuleAccess.Scope.OPERATE),
+			(cls.gudang_without_facility, ModuleAccess.Scope.OPERATE),
 			(cls.staff_user, ModuleAccess.Scope.MANAGE),
 		):
 			ModuleAccess.objects.update_or_create(
@@ -303,6 +317,7 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 			username="auditor_lplpo_view_only",
 			password="TestPassword123!",
 			role=User.Role.AUDITOR,
+			facility=self.facility,
 		)
 		ModuleAccess.objects.update_or_create(
 			user=auditor_user,
@@ -1037,8 +1052,47 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 		self.client.force_login(self.puskesmas_user)
 		response = self.client.get(reverse("lplpo:lplpo_detail", args=[lplpo.pk]))
 
-		self.assertEqual(response.status_code, 302)
-		self.assertRedirects(response, reverse("lplpo:lplpo_my_list"))
+		self.assertEqual(response.status_code, 403)
+
+	def test_non_superuser_without_facility_cannot_view_lplpo_list(self):
+		self.client.force_login(self.gudang_without_facility)
+
+		response = self.client.get(reverse("lplpo:lplpo_list"))
+
+		self.assertEqual(response.status_code, 403)
+
+	def test_non_superuser_list_is_scoped_to_linked_facility(self):
+		matching = self.create_lplpo(
+			facility=self.facility,
+			status=LPLPO.Status.SUBMITTED,
+		)
+		self.set_submitted_at(matching, 2026, 4, 18)
+		other = self.create_lplpo(
+			facility=self.other_facility,
+			created_by=self.other_puskesmas_user,
+			bulan=5,
+			tahun=2026,
+			status=LPLPO.Status.SUBMITTED,
+		)
+		self.set_submitted_at(other, 2026, 5, 2)
+
+		self.client.force_login(self.gudang_user)
+		response = self.client.get(reverse("lplpo:lplpo_list"))
+
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, matching.document_number)
+		self.assertNotContains(response, other.document_number)
+
+	def test_non_superuser_cannot_view_other_facility_lplpo(self):
+		lplpo = self.create_lplpo(
+			facility=self.other_facility,
+			created_by=self.other_puskesmas_user,
+		)
+
+		self.client.force_login(self.gudang_user)
+		response = self.client.get(reverse("lplpo:lplpo_detail", args=[lplpo.pk]))
+
+		self.assertEqual(response.status_code, 403)
 
 	def test_puskesmas_cannot_access_review(self):
 		lplpo = self.create_lplpo(status=LPLPO.Status.PIC_VERIFIED)
@@ -1431,6 +1485,30 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 		self.assertContains(response, matching.document_number)
 		self.assertNotContains(response, non_matching.document_number)
 
+	def test_non_superuser_print_report_is_scoped_to_linked_facility(self):
+		matching = self.create_lplpo(
+			facility=self.facility,
+			status=LPLPO.Status.SUBMITTED,
+			bulan=4,
+			tahun=2026,
+		)
+		self.set_submitted_at(matching, 2026, 4, 18)
+		other = self.create_lplpo(
+			facility=self.other_facility,
+			created_by=self.other_puskesmas_user,
+			bulan=5,
+			tahun=2026,
+			status=LPLPO.Status.SUBMITTED,
+		)
+		self.set_submitted_at(other, 2026, 5, 2)
+
+		self.client.force_login(self.gudang_user)
+		response = self.client.get(reverse("lplpo:lplpo_print_report"))
+
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, matching.document_number)
+		self.assertNotContains(response, other.document_number)
+
 	def test_super_admin_print_report_still_only_shows_submitted_documents(self):
 		draft_lplpo = self.create_lplpo(status=LPLPO.Status.DRAFT)
 		submitted_lplpo = self.create_lplpo(
@@ -1490,6 +1568,55 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 		self.assertEqual(
 			response.json()["unit_prices"][str(self.item_a.pk)],
 			"1400.00",
+		)
+
+	def test_non_superuser_prefill_uses_linked_facility_even_with_other_facility_param(self):
+		self.create_distribution(
+			facility=self.facility,
+			distributed_date=date(2026, 2, 11),
+			item_quantities=[(self.item_a, Decimal("4.00"))],
+			item_unit_prices={self.item_a.pk: Decimal("1400.00")},
+		)
+		self.create_distribution(
+			facility=self.other_facility,
+			distributed_date=date(2026, 2, 15),
+			item_quantities=[(self.item_a, Decimal("99.00"))],
+			item_unit_prices={self.item_a.pk: Decimal("2500.00")},
+		)
+		self.client.force_login(self.gudang_user)
+
+		response = self.client.get(
+			reverse("lplpo:api_prefill_penerimaan"),
+			{
+				"bulan": 2,
+				"tahun": 2026,
+				"facility": self.other_facility.pk,
+			},
+		)
+
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(response.json()["facility_id"], self.facility.pk)
+		self.assertEqual(
+			response.json()["items"][str(self.item_a.pk)],
+			"4",
+		)
+		self.assertEqual(
+			response.json()["unit_prices"][str(self.item_a.pk)],
+			"1400.00",
+		)
+
+	def test_non_superuser_without_facility_prefill_returns_403(self):
+		self.client.force_login(self.gudang_without_facility)
+
+		response = self.client.get(
+			reverse("lplpo:api_prefill_penerimaan"),
+			{"bulan": 2, "tahun": 2026},
+		)
+
+		self.assertEqual(response.status_code, 403)
+		self.assertEqual(
+			response.json()["detail"],
+			"Akun Anda belum terhubung ke fasilitas.",
 		)
 
 	def test_api_prefill_penerimaan_returns_empty_for_january_bootstrap(self):
@@ -1658,6 +1785,7 @@ class LPLPOWorkflowTests(LPLPOTestCase):
 			{
 				f"item_{line.pk}-stock_awal": "1.00",
 				f"item_{line.pk}-penerimaan": "2.00",
+				f"item_{line.pk}-harga_satuan": "0.00",
 				f"item_{line.pk}-pemakaian": "1.00",
 				f"item_{line.pk}-stock_gudang_puskesmas": "0.00",
 				f"item_{line.pk}-waktu_kosong": "0.00",

--- a/backend/apps/lplpo/views.py
+++ b/backend/apps/lplpo/views.py
@@ -42,20 +42,26 @@ def _is_super_admin(user):
     return bool(getattr(user, "is_superuser", False))
 
 
+def _get_required_facility(user):
+    if _is_super_admin(user):
+        return None
+
+    facility = getattr(user, "facility", None)
+    if not facility:
+        raise PermissionDenied("Akun Anda belum terhubung ke fasilitas.")
+    return facility
+
+
 def _check_facility_access(request, lplpo_obj):
     """
-    Returns a redirect response if the current PUSKESMAS user is trying
-    to access an LPLPO that belongs to a different facility.
-    Returns None if access is allowed.
+    Enforce per-facility access for every non-superuser.
     """
-    if _is_super_admin(request.user) or request.user.role != User.Role.PUSKESMAS:
+    if _is_super_admin(request.user):
         return None
-    if not request.user.facility:
-        messages.error(request, "Akun Anda belum terhubung ke fasilitas.")
-        return redirect("lplpo:lplpo_my_list")
-    if lplpo_obj.facility_id != request.user.facility_id:
-        messages.error(request, "Anda tidak memiliki akses ke LPLPO ini.")
-        return redirect("lplpo:lplpo_my_list")
+
+    facility = _get_required_facility(request.user)
+    if lplpo_obj.facility_id != facility.pk:
+        raise PermissionDenied("Anda tidak memiliki akses ke LPLPO ini.")
     return None
 
 
@@ -197,6 +203,10 @@ def _get_filtered_lplpo_queryset(request, *, submitted_only=True):
     submitted_year = request.GET.get("submitted_year", "").strip()
     if submitted_year:
         queryset = queryset.filter(submitted_at__year=submitted_year)
+
+    if not _is_super_admin(request.user):
+        facility = _get_required_facility(request.user)
+        queryset = queryset.filter(facility=facility)
 
     return queryset, {
         "search": q,
@@ -442,21 +452,29 @@ def api_prefill_penerimaan(request):
         return JsonResponse({"detail": "Method not allowed."}, status=405)
 
     facility = request.user.facility
-    if request.user.role != User.Role.PUSKESMAS:
-        if not has_module_scope(
-            request.user, ModuleAccess.Module.LPLPO, ModuleAccess.Scope.OPERATE
-        ):
-            return JsonResponse({"detail": "Insufficient permissions."}, status=403)
+    if _is_super_admin(request.user):
         facility_id = request.GET.get("facility")
         if facility_id:
-            from apps.items.models import Facility
-
             facility = get_object_or_404(
                 Facility,
                 pk=facility_id,
                 facility_type="PUSKESMAS",
                 is_active=True,
             )
+    elif request.user.role != User.Role.PUSKESMAS:
+        if not has_module_scope(
+            request.user, ModuleAccess.Module.LPLPO, ModuleAccess.Scope.OPERATE
+        ):
+            return JsonResponse({"detail": "Insufficient permissions."}, status=403)
+        try:
+            facility = _get_required_facility(request.user)
+        except PermissionDenied as exc:
+            return JsonResponse({"detail": str(exc)}, status=403)
+    else:
+        try:
+            facility = _get_required_facility(request.user)
+        except PermissionDenied as exc:
+            return JsonResponse({"detail": str(exc)}, status=403)
 
     if not facility:
         return JsonResponse(
@@ -764,6 +782,9 @@ def lplpo_verify(request, pk):
             LPLPO.objects.select_for_update(),
             pk=pk,
         )
+        denied = _check_facility_access(request, lplpo_obj)
+        if denied:
+            return denied
 
         if lplpo_obj.status != LPLPO.Status.SUBMITTED:
             messages.error(
@@ -814,6 +835,9 @@ def lplpo_reject(request, pk):
             LPLPO.objects.select_for_update(),
             pk=pk,
         )
+        denied = _check_facility_access(request, lplpo_obj)
+        if denied:
+            return denied
 
         if lplpo_obj.status == LPLPO.Status.SUBMITTED:
             if not _has_lplpo_operate_access(request.user):
@@ -866,6 +890,9 @@ def lplpo_review(request, pk):
         return denied
 
     lplpo_obj = get_object_or_404(LPLPO.objects.select_related("facility"), pk=pk)
+    denied = _check_facility_access(request, lplpo_obj)
+    if denied:
+        return denied
 
     if lplpo_obj.status not in (
         LPLPO.Status.PIC_VERIFIED,
@@ -1019,6 +1046,9 @@ def lplpo_finalize(request, pk):
         return denied
 
     lplpo_obj = get_object_or_404(LPLPO.objects.select_related("facility"), pk=pk)
+    denied = _check_facility_access(request, lplpo_obj)
+    if denied:
+        return denied
     if request.method != "POST":
         return redirect("lplpo:lplpo_detail", pk=pk)
 

--- a/backend/apps/lplpo/views.py
+++ b/backend/apps/lplpo/views.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 def _is_super_admin(user):
-    return bool(getattr(user, "is_superuser", False))
+    return bool(getattr(user, "is_superuser", False)) or getattr(user, "role", None) == User.Role.ADMIN
 
 
 def _get_required_facility(user):
@@ -451,7 +451,7 @@ def api_prefill_penerimaan(request):
     if request.method != "GET":
         return JsonResponse({"detail": "Method not allowed."}, status=405)
 
-    facility = request.user.facility
+    facility = None
     if _is_super_admin(request.user):
         facility_id = request.GET.get("facility")
         if facility_id:
@@ -461,20 +461,16 @@ def api_prefill_penerimaan(request):
                 facility_type="PUSKESMAS",
                 is_active=True,
             )
-    elif request.user.role != User.Role.PUSKESMAS:
-        if not has_module_scope(
-            request.user, ModuleAccess.Module.LPLPO, ModuleAccess.Scope.OPERATE
-        ):
-            return JsonResponse({"detail": "Insufficient permissions."}, status=403)
-        try:
-            facility = _get_required_facility(request.user)
-        except PermissionDenied as exc:
-            return JsonResponse({"detail": str(exc)}, status=403)
     else:
+        if request.user.role != User.Role.PUSKESMAS:
+            if not has_module_scope(
+                request.user, ModuleAccess.Module.LPLPO, ModuleAccess.Scope.OPERATE
+            ):
+                return JsonResponse({"detail": "Insufficient permissions."}, status=403)
         try:
             facility = _get_required_facility(request.user)
-        except PermissionDenied as exc:
-            return JsonResponse({"detail": str(exc)}, status=403)
+        except PermissionDenied:
+            return JsonResponse({"detail": "Akun Anda belum terhubung ke fasilitas."}, status=403)
 
     if not facility:
         return JsonResponse(

--- a/backend/apps/puskesmas/tests.py
+++ b/backend/apps/puskesmas/tests.py
@@ -72,8 +72,9 @@ class PuskesmasRequestFormTests(TestCase):
 		self.assertEqual(form.fields["item"].label_from_instance(self.item), "Haloperidol 5 mg")
 
 
-class PuskesmasRequestCreateViewTests(TestCase):
+class PuskesmasRequestCreateViewTests(SecureClientDefaultsMixin, TestCase):
 	def setUp(self):
+		super().setUp()
 		self.unit = Unit.objects.create(code="TAB", name="Tablet")
 		self.category = Category.objects.create(code="OBT", name="Obat", sort_order=1)
 		self.facility = Facility.objects.create(
@@ -109,6 +110,13 @@ class PuskesmasRequestCreateViewTests(TestCase):
 			role=User.Role.PUSKESMAS,
 			facility=self.other_facility,
 		)
+		self.staff_facility_user = User.objects.create_user(
+			username="admin-umum-facility",
+			password="TestPassword123!",
+			role=User.Role.ADMIN_UMUM,
+			facility=self.facility,
+		)
+		ensure_default_module_access(self.staff_facility_user, overwrite=True)
 
 	def test_create_binds_request_to_logged_in_facility(self):
 		self.client.force_login(self.user)
@@ -222,7 +230,7 @@ class PuskesmasRequestCreateViewTests(TestCase):
 		self.assertContains(response, own_request.document_number)
 		self.assertNotContains(response, other_request.document_number)
 
-	def test_detail_redirects_when_operator_accesses_other_facility_request(self):
+	def test_detail_returns_403_when_operator_accesses_other_facility_request(self):
 		other_request = PuskesmasRequest.objects.create(
 			facility=self.other_facility,
 			created_by=self.other_user,
@@ -233,10 +241,9 @@ class PuskesmasRequestCreateViewTests(TestCase):
 			reverse("puskesmas:request_detail", args=[other_request.pk])
 		)
 
-		self.assertEqual(response.status_code, 302)
-		self.assertRedirects(response, reverse("puskesmas:request_list"))
+		self.assertEqual(response.status_code, 403)
 
-	def test_edit_redirects_when_operator_accesses_other_facility_request(self):
+	def test_edit_returns_403_when_operator_accesses_other_facility_request(self):
 		other_request = PuskesmasRequest.objects.create(
 			facility=self.other_facility,
 			created_by=self.other_user,
@@ -247,10 +254,9 @@ class PuskesmasRequestCreateViewTests(TestCase):
 			reverse("puskesmas:request_edit", args=[other_request.pk])
 		)
 
-		self.assertEqual(response.status_code, 302)
-		self.assertRedirects(response, reverse("puskesmas:request_list"))
+		self.assertEqual(response.status_code, 403)
 
-	def test_submit_redirects_when_operator_accesses_other_facility_request(self):
+	def test_submit_returns_403_when_operator_accesses_other_facility_request(self):
 		other_request = PuskesmasRequest.objects.create(
 			facility=self.other_facility,
 			status=PuskesmasRequest.Status.DRAFT,
@@ -267,12 +273,11 @@ class PuskesmasRequestCreateViewTests(TestCase):
 			reverse("puskesmas:request_submit", args=[other_request.pk])
 		)
 
-		self.assertEqual(response.status_code, 302)
-		self.assertRedirects(response, reverse("puskesmas:request_list"))
+		self.assertEqual(response.status_code, 403)
 		other_request.refresh_from_db()
 		self.assertEqual(other_request.status, PuskesmasRequest.Status.DRAFT)
 
-	def test_kepala_with_missing_module_rows_can_still_view_request_list(self):
+	def test_non_superuser_without_facility_cannot_view_request_list(self):
 		kepala = User.objects.create_user(
 			username="kepala-legacy",
 			password="TestPassword123!",
@@ -287,10 +292,9 @@ class PuskesmasRequestCreateViewTests(TestCase):
 		self.client.force_login(kepala)
 		response = self.client.get(reverse("puskesmas:request_list"))
 
-		self.assertEqual(response.status_code, 200)
-		self.assertContains(response, "Permintaan Barang Puskesmas")
+		self.assertEqual(response.status_code, 403)
 
-	def test_admin_umum_with_missing_module_rows_can_view_request_detail(self):
+	def test_non_superuser_without_facility_cannot_view_request_detail(self):
 		admin_umum = User.objects.create_user(
 			username="admin-umum-legacy",
 			password="TestPassword123!",
@@ -305,8 +309,35 @@ class PuskesmasRequestCreateViewTests(TestCase):
 		self.client.force_login(admin_umum)
 		response = self.client.get(reverse("puskesmas:request_detail", args=[req.pk]))
 
+		self.assertEqual(response.status_code, 403)
+
+	def test_non_superuser_with_facility_list_is_scoped(self):
+		own_request = PuskesmasRequest.objects.create(
+			facility=self.facility,
+			created_by=self.user,
+		)
+		other_request = PuskesmasRequest.objects.create(
+			facility=self.other_facility,
+			created_by=self.other_user,
+		)
+
+		self.client.force_login(self.staff_facility_user)
+		response = self.client.get(reverse("puskesmas:request_list"))
+
 		self.assertEqual(response.status_code, 200)
-		self.assertContains(response, req.document_number)
+		self.assertContains(response, own_request.document_number)
+		self.assertNotContains(response, other_request.document_number)
+
+	def test_non_superuser_with_facility_cannot_view_other_facility_request(self):
+		other_request = PuskesmasRequest.objects.create(
+			facility=self.other_facility,
+			created_by=self.other_user,
+		)
+
+		self.client.force_login(self.staff_facility_user)
+		response = self.client.get(reverse("puskesmas:request_detail", args=[other_request.pk]))
+
+		self.assertEqual(response.status_code, 403)
 
 	def test_explicit_none_scope_cannot_view_request_list(self):
 		auditor = User.objects.create_user(
@@ -326,8 +357,9 @@ class PuskesmasRequestCreateViewTests(TestCase):
 		self.assertEqual(response.status_code, 403)
 
 
-class PuskesmasRequestApprovalTests(TestCase):
+class PuskesmasRequestApprovalTests(SecureClientDefaultsMixin, TestCase):
 	def setUp(self):
+		super().setUp()
 		self.unit = Unit.objects.create(code="TAB", name="Tablet")
 		self.category = Category.objects.create(code="OBT", name="Obat", sort_order=1)
 		self.facility = Facility.objects.create(
@@ -351,6 +383,7 @@ class PuskesmasRequestApprovalTests(TestCase):
 			username="approver-root",
 			password="TestPassword123!",
 			role=User.Role.KEPALA,
+			facility=self.facility,
 		)
 		self.manager = User.objects.create_superuser(
 			username="manager-puskesmas",
@@ -366,6 +399,17 @@ class PuskesmasRequestApprovalTests(TestCase):
 			user=self.manager,
 			module=ModuleAccess.Module.PUSKESMAS,
 			defaults={"scope": ModuleAccess.Scope.MANAGE},
+		)
+		self.other_facility = Facility.objects.create(
+			code="PKM-02",
+			name="Puskesmas Dua",
+			facility_type=Facility.FacilityType.PUSKESMAS,
+		)
+		self.other_requester = User.objects.create_user(
+			username="operator-submit-other",
+			password="TestPassword123!",
+			role=User.Role.PUSKESMAS,
+			facility=self.other_facility,
 		)
 
 	def test_approve_creates_distribution_with_requested_and_approved_quantities(self):
@@ -550,6 +594,30 @@ class PuskesmasRequestApprovalTests(TestCase):
 		self.assertEqual(response.status_code, 302)
 		req.refresh_from_db()
 		self.assertEqual(req.status, PuskesmasRequest.Status.SUBMITTED)
+
+	def test_approver_cannot_approve_other_facility_request(self):
+		req = PuskesmasRequest.objects.create(
+			facility=self.other_facility,
+			request_date="2026-04-02",
+			status=PuskesmasRequest.Status.SUBMITTED,
+			created_by=self.other_requester,
+		)
+		item_line = PuskesmasRequestItem.objects.create(
+			request=req,
+			item=self.item,
+			quantity_requested=Decimal("8.00"),
+		)
+
+		self.client.force_login(self.approver)
+		response = self.client.post(
+			reverse("puskesmas:request_approve", args=[req.pk]),
+			{f"approve_{item_line.pk}-quantity_approved": "5.00"},
+		)
+
+		self.assertEqual(response.status_code, 403)
+		req.refresh_from_db()
+		self.assertEqual(req.status, PuskesmasRequest.Status.SUBMITTED)
+		self.assertIsNone(req.distribution)
 
 
 class PuskesmasReportViewTests(SecureClientDefaultsMixin, TestCase):

--- a/backend/apps/puskesmas/views.py
+++ b/backend/apps/puskesmas/views.py
@@ -23,11 +23,27 @@ from .forms import (
 from .models import PuskesmasRequest, PuskesmasRequestItem
 
 
+def _is_super_admin(user):
+    return bool(getattr(user, "is_superuser", False))
+
+
+def _get_required_facility(user):
+    if _is_super_admin(user):
+        return None
+
+    facility = getattr(user, "facility", None)
+    if not facility:
+        raise PermissionDenied(
+            "Akun Anda belum terhubung ke fasilitas puskesmas."
+        )
+    return facility
+
+
 def _can_review_request(user):
     if not getattr(user, "is_authenticated", False):
         return False
 
-    if user.is_superuser:
+    if _is_super_admin(user):
         return True
 
     if getattr(user, "role", None) == "PUSKESMAS":
@@ -46,13 +62,18 @@ def _can_manage_request(user, req=None):
     if not getattr(user, "is_authenticated", False):
         return False
 
-    if user.is_superuser:
+    if _is_super_admin(user):
         return True
 
+    facility = getattr(user, "facility", None)
+    if not facility:
+        return False
+
+    if req is not None and req.facility_id != facility.pk:
+        return False
+
     if getattr(user, "role", None) == "PUSKESMAS":
-        if not user.facility_id:
-            return False
-        return req is None or req.facility_id == user.facility_id
+        return True
 
     return has_module_permission(
         user, "puskesmas.change_puskesmasrequest"
@@ -74,16 +95,12 @@ def _can_reset_request_to_draft(user, req):
 
 
 def _check_request_facility_access(request, req):
-    if getattr(request.user, "role", None) != "PUSKESMAS":
+    if _is_super_admin(request.user):
         return None
 
-    if not request.user.facility_id:
-        messages.error(request, "Akun Anda belum terhubung ke fasilitas puskesmas.")
-        return redirect("puskesmas:request_list")
-
-    if req.facility_id != request.user.facility_id:
-        messages.error(request, "Anda tidak memiliki akses ke permintaan ini.")
-        return redirect("puskesmas:request_list")
+    facility = _get_required_facility(request.user)
+    if req.facility_id != facility.pk:
+        raise PermissionDenied("Anda tidak memiliki akses ke permintaan ini.")
 
     return None
 
@@ -104,11 +121,9 @@ def request_list(request):
         "facility", "created_by", "program"
     ).order_by("-request_date")
 
-    if getattr(request.user, "role", None) == "PUSKESMAS":
-        if request.user.facility_id:
-            queryset = queryset.filter(facility_id=request.user.facility_id)
-        else:
-            queryset = queryset.none()
+    if not _is_super_admin(request.user):
+        facility = _get_required_facility(request.user)
+        queryset = queryset.filter(facility_id=facility.pk)
 
     q = request.GET.get("q", "").strip()
     if q:
@@ -318,6 +333,9 @@ def request_approve(request, pk):
         raise PermissionDenied("Operator Puskesmas tidak dapat menyetujui permintaan.")
 
     req = get_object_or_404(PuskesmasRequest, pk=pk)
+    denied = _check_request_facility_access(request, req)
+    if denied:
+        return denied
     if request.method != "POST":
         return redirect("puskesmas:request_detail", pk=pk)
 
@@ -420,6 +438,9 @@ def request_reject(request, pk):
         raise PermissionDenied("Operator Puskesmas tidak dapat menolak permintaan.")
 
     req = get_object_or_404(PuskesmasRequest, pk=pk)
+    denied = _check_request_facility_access(request, req)
+    if denied:
+        return denied
     if request.method != "POST":
         return redirect("puskesmas:request_detail", pk=pk)
 
@@ -616,7 +637,7 @@ def puskesmas_report_penerimaan(request):
 
     # Facility chooser for super admin
     all_facilities = []
-    if not getattr(request.user, "role", None) == "PUSKESMAS":
+    if _is_super_admin(request.user):
         all_facilities = FacilityModel.objects.filter(
             facility_type=FacilityModel.FacilityType.PUSKESMAS, is_active=True
         ).order_by("name")
@@ -721,7 +742,7 @@ def puskesmas_report_pemakaian(request):
 
     # Facility chooser for super admin
     all_facilities = []
-    if not getattr(request.user, "role", None) == "PUSKESMAS":
+    if _is_super_admin(request.user):
         all_facilities = FacilityModel.objects.filter(
             facility_type=FacilityModel.FacilityType.PUSKESMAS, is_active=True
         ).order_by("name")
@@ -930,7 +951,7 @@ def puskesmas_report_persediaan(request):
 
     # Facility chooser for super admin
     all_facilities = []
-    if not getattr(request.user, "role", None) == "PUSKESMAS":
+    if _is_super_admin(request.user):
         all_facilities = FacilityModel.objects.filter(
             facility_type=FacilityModel.FacilityType.PUSKESMAS, is_active=True
         ).order_by("name")
@@ -1120,7 +1141,7 @@ def puskesmas_report_rekap_persediaan(request):
             )
 
     all_facilities = []
-    if not getattr(request.user, "role", None) == "PUSKESMAS":
+    if _is_super_admin(request.user):
         all_facilities = FacilityModel.objects.filter(
             facility_type=FacilityModel.FacilityType.PUSKESMAS, is_active=True
         ).order_by("name")

--- a/backend/apps/puskesmas/views.py
+++ b/backend/apps/puskesmas/views.py
@@ -13,7 +13,7 @@ from apps.core.decorators import module_scope_required, perm_required
 from apps.distribution.models import Distribution, DistributionItem
 from apps.distribution.services import assign_default_distribution_staff
 from apps.users.access import has_module_permission, has_module_scope
-from apps.users.models import ModuleAccess
+from apps.users.models import ModuleAccess, User
 
 from .forms import (
     ApprovalItemForm,
@@ -24,7 +24,7 @@ from .models import PuskesmasRequest, PuskesmasRequestItem
 
 
 def _is_super_admin(user):
-    return bool(getattr(user, "is_superuser", False))
+    return bool(getattr(user, "is_superuser", False)) or getattr(user, "role", None) == User.Role.ADMIN
 
 
 def _get_required_facility(user):


### PR DESCRIPTION
## Summary
- enforce linked-facility tenancy across puskesmas request surfaces for every non-superuser
- scope LPLPO queue, detail, print, verify, review, reject, finalize, and prefill flows to the actor facility unless the actor is a superuser
- update docs and regression tests to reflect the stricter demo-data isolation model

## Testing
- python manage.py test --keepdb apps.puskesmas.tests.PuskesmasRequestCreateViewTests apps.puskesmas.tests.PuskesmasRequestApprovalTests apps.lplpo.tests.LPLPOWorkflowTests

Closes #118