### PR TITLE
[codex] Refine Puskesmas Poli/Pustu input UX

### DIFF
--- a/backend/apps/puskesmas/forms.py
+++ b/backend/apps/puskesmas/forms.py
@@ -300,16 +300,13 @@ PuskesmasSBBKItemFormSet = inlineformset_factory(
 class PuskesmasSubunitForm(forms.ModelForm):
     class Meta:
         model = PuskesmasSubunit
-        fields = ["facility", "name", "subunit_type", "sort_order", "is_active"]
+        fields = ["facility", "name", "subunit_type", "is_active"]
         widgets = {
             "facility": forms.Select(attrs={"class": "form-select"}),
             "name": forms.TextInput(
                 attrs={"class": "form-control", "placeholder": "Contoh: Poli Umum"}
             ),
             "subunit_type": forms.Select(attrs={"class": "form-select"}),
-            "sort_order": forms.NumberInput(
-                attrs={"class": "form-control", "min": "0", "step": "1"}
-            ),
             "is_active": forms.CheckboxInput(attrs={"class": "form-check-input"}),
         }
 
@@ -323,8 +320,24 @@ class PuskesmasSubunitForm(forms.ModelForm):
             Div("facility", css_class="mb-3"),
             Div("name", css_class="mb-3"),
             Div("subunit_type", css_class="mb-3"),
-            Div("sort_order", css_class="mb-3"),
             Div("is_active", css_class="form-check mb-0"),
+        )
+
+        self.fields["facility"].label = "Puskesmas"
+        self.fields["facility"].widget.attrs["title"] = (
+            "Pilih puskesmas yang memiliki poli atau pustu ini."
+        )
+        self.fields["name"].label = "Nama Poli/Pustu"
+        self.fields["name"].widget.attrs["title"] = (
+            "Isi nama poli atau pustu sesuai penamaan yang digunakan di puskesmas."
+        )
+        self.fields["subunit_type"].label = "Jenis Poli/Pustu"
+        self.fields["subunit_type"].widget.attrs["title"] = (
+            "Pilih Poli untuk layanan di dalam puskesmas atau Pustu untuk layanan di luar gedung utama."
+        )
+        self.fields["is_active"].label = "Aktif"
+        self.fields["is_active"].widget.attrs["title"] = (
+            "Matikan jika poli atau pustu ini tidak lagi dipakai sebagai kolom input."
         )
 
         self.fields["facility"].queryset = Facility.objects.filter(
@@ -361,7 +374,7 @@ class PuskesmasSubunitForm(forms.ModelForm):
     def clean_name(self):
         return _normalize_text_value(
             self.cleaned_data.get("name"),
-            field_label="Nama subunit",
+            field_label="Nama Poli/Pustu",
             max_length=120,
         )
 
@@ -410,6 +423,23 @@ class PuskesmasConsumptionMatrixForm(forms.ModelForm):
             Div("notes", css_class="mb-0"),
         )
 
+        self.fields["facility"].label = "Puskesmas"
+        self.fields["facility"].widget.attrs["title"] = (
+            "Pilih puskesmas yang akan mengisi pemakaian rinci."
+        )
+        self.fields["bulan"].label = "Bulan"
+        self.fields["bulan"].widget.attrs["title"] = (
+            "Masukkan bulan periode pemakaian yang sedang dilaporkan."
+        )
+        self.fields["tahun"].label = "Tahun"
+        self.fields["tahun"].widget.attrs["title"] = (
+            "Masukkan tahun periode pemakaian yang sedang dilaporkan."
+        )
+        self.fields["notes"].label = "Catatan"
+        self.fields["notes"].widget.attrs["title"] = (
+            "Isi catatan tambahan bila ada kondisi khusus pada periode pemakaian ini."
+        )
+
         self.fields["facility"].queryset = Facility.objects.filter(
             facility_type=Facility.FacilityType.PUSKESMAS,
             is_active=True,
@@ -441,6 +471,14 @@ class PuskesmasConsumptionMatrixForm(forms.ModelForm):
                             "class": "form-control form-control-sm text-end",
                             "min": "0",
                             "step": "1",
+                            "placeholder": "0",
+                            "title": (
+                                f"Isi jumlah pemakaian {item.nama_barang} yang digunakan di "
+                                f"{subunit.name} pada periode ini."
+                            ),
+                            "aria-label": (
+                                f"Pemakaian {item.nama_barang} untuk {subunit.name}"
+                            ),
                         }
                     ),
                     label=f"{item.picker_label} / {subunit.name}",

--- a/backend/apps/puskesmas/tests.py
+++ b/backend/apps/puskesmas/tests.py
@@ -1,11 +1,13 @@
 from decimal import Decimal
 from io import BytesIO
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 from openpyxl import load_workbook
 
 from apps.core.tests.mixins import SecureClientDefaultsMixin
@@ -30,6 +32,7 @@ from apps.puskesmas.models import (
 	PuskesmasSubunit,
 )
 from apps.puskesmas.services import assert_consumption_month_mutable
+from apps.puskesmas.views import _get_consumption_subunits
 from apps.users.access import ensure_default_module_access
 from apps.users.models import ModuleAccess, User
 from apps.lplpo.models import LPLPO, LPLPOItem
@@ -299,6 +302,14 @@ class PuskesmasConsumptionFormTests(TestCase):
 		self.assertEqual(form.cleaned_data["facility"], self.facility)
 		self.assertEqual(form.cleaned_data["name"], "Poli Gigi")
 
+	def test_subunit_form_uses_indonesian_labels_and_hover_titles(self):
+		form = PuskesmasSubunitForm(user=self.user)
+
+		self.assertEqual(form.fields["name"].label, "Nama Poli/Pustu")
+		self.assertEqual(form.fields["subunit_type"].label, "Jenis Poli/Pustu")
+		self.assertIn("poli atau pustu", form.fields["name"].widget.attrs["title"].lower())
+		self.assertNotIn("sort_order", form.fields)
+
 	def test_subunit_form_rejects_facility_change_after_consumption_history_exists(self):
 		admin = User.objects.create_superuser(
 			username="admin-subunit-form",
@@ -355,6 +366,19 @@ class PuskesmasConsumptionFormTests(TestCase):
 		self.assertFalse(form.is_valid())
 		self.assertIn(f"qty_{self.item.pk}_{self.subunit.pk}", form.errors)
 
+	def test_consumption_form_adds_hover_information_to_matrix_inputs(self):
+		form = PuskesmasConsumptionMatrixForm(
+			user=self.user,
+			subunits=[self.subunit],
+			items=[self.item],
+		)
+
+		field = form.fields[f"qty_{self.item.pk}_{self.subunit.pk}"]
+		self.assertEqual(form.fields["bulan"].label, "Bulan")
+		self.assertIn("periode pemakaian", form.fields["bulan"].widget.attrs["title"].lower())
+		self.assertEqual(field.widget.attrs["placeholder"], "0")
+		self.assertIn(self.subunit.name, field.widget.attrs["title"])
+
 	def test_assert_consumption_month_mutable_uses_row_lock_when_requested(self):
 		lplpo = LPLPO.objects.create(
 			facility=self.facility,
@@ -383,6 +407,29 @@ class PuskesmasConsumptionFormTests(TestCase):
 		)
 		mocked_queryset.select_for_update.assert_called_once_with()
 		self.assertEqual(result, lplpo)
+
+	def test_consumption_subunits_follow_creation_time_order(self):
+		older_subunit = PuskesmasSubunit.objects.create(
+			facility=self.facility,
+			name="Poli Z",
+			subunit_type=PuskesmasSubunit.SubunitType.TREATMENT_ROOM,
+		)
+		newer_subunit = PuskesmasSubunit.objects.create(
+			facility=self.facility,
+			name="Poli A",
+			subunit_type=PuskesmasSubunit.SubunitType.TREATMENT_ROOM,
+		)
+		now = timezone.now()
+		PuskesmasSubunit.objects.filter(pk=older_subunit.pk).update(
+			created_at=now - timedelta(minutes=2)
+		)
+		PuskesmasSubunit.objects.filter(pk=newer_subunit.pk).update(
+			created_at=now - timedelta(minutes=1)
+		)
+
+		subunits = _get_consumption_subunits(self.facility)
+
+		self.assertEqual([subunit.pk for subunit in subunits[:2]], [older_subunit.pk, newer_subunit.pk])
 
 
 class PuskesmasSBBKViewTests(SecureClientDefaultsMixin, TestCase):

--- a/backend/apps/puskesmas/views.py
+++ b/backend/apps/puskesmas/views.py
@@ -217,7 +217,7 @@ def _get_consumption_subunits(facility, *, consumption=None):
         queryset = queryset.filter(
             Q(is_active=True) | Q(consumption_entries__consumption=consumption)
         ).distinct()
-    return list(queryset.order_by("sort_order", "name"))
+    return list(queryset.order_by("created_at", "name"))
 
 
 def _get_consumption_items(*, consumption=None):
@@ -280,7 +280,7 @@ def _request_has_consumption_matrix_input(request):
 @perm_required("puskesmas.view_puskesmassubunit")
 def subunit_list(request):
     queryset = PuskesmasSubunit.objects.select_related("facility").order_by(
-        "facility__name", "sort_order", "name"
+        "facility__name", "created_at", "name"
     )
 
     if not _is_super_admin(request.user):
@@ -329,7 +329,7 @@ def subunit_create(request):
                     "username": request.user.username,
                 },
             )
-            messages.success(request, f"Subunit {subunit.name} berhasil dibuat.")
+            messages.success(request, f"Poli/Pustu {subunit.name} berhasil dibuat.")
             return redirect("puskesmas:subunit_list")
     else:
         form = PuskesmasSubunitForm(user=request.user)
@@ -339,7 +339,7 @@ def subunit_create(request):
         "puskesmas/subunit_form.html",
         {
             "form": form,
-            "title": "Buat Subunit Puskesmas",
+            "title": "Buat Poli/Pustu Puskesmas",
             "is_edit": False,
         },
     )
@@ -367,7 +367,7 @@ def subunit_edit(request, pk):
             )
             messages.success(
                 request,
-                f"Subunit {updated_subunit.name} berhasil diperbarui.",
+                f"Poli/Pustu {updated_subunit.name} berhasil diperbarui.",
             )
             return redirect("puskesmas:subunit_list")
     else:
@@ -378,7 +378,7 @@ def subunit_edit(request, pk):
         "puskesmas/subunit_form.html",
         {
             "form": form,
-            "title": f"Edit Subunit {subunit.name}",
+            "title": f"Ubah Poli/Pustu {subunit.name}",
             "is_edit": True,
             "subunit": subunit,
         },
@@ -399,7 +399,7 @@ def subunit_delete(request, pk):
     if subunit.consumption_entries.exists():
         messages.error(
             request,
-            "Subunit tidak dapat dihapus karena sudah dipakai pada data pemakaian. Nonaktifkan subunit ini sebagai gantinya.",
+            "Poli/Pustu tidak dapat dihapus karena sudah dipakai pada data pemakaian. Nonaktifkan entri ini sebagai gantinya.",
         )
         return redirect("puskesmas:subunit_list")
 
@@ -414,7 +414,7 @@ def subunit_delete(request, pk):
             "username": request.user.username,
         },
     )
-    messages.success(request, f"Subunit {subunit_name} berhasil dihapus.")
+    messages.success(request, f"Poli/Pustu {subunit_name} berhasil dihapus.")
     return redirect("puskesmas:subunit_list")
 
 
@@ -497,7 +497,7 @@ def consumption_create(request):
             elif not subunits:
                 form.add_error(
                     None,
-                    "Tambahkan minimal 1 subunit aktif sebelum menyimpan pemakaian.",
+                    "Tambahkan minimal 1 Poli/Pustu aktif sebelum menyimpan pemakaian.",
                 )
             else:
                 try:
@@ -642,7 +642,7 @@ def consumption_edit(request, pk):
             if not subunits:
                 form.add_error(
                     None,
-                    "Tambahkan minimal 1 subunit aktif sebelum menyimpan pemakaian.",
+                    "Tambahkan minimal 1 Poli/Pustu aktif sebelum menyimpan pemakaian.",
                 )
             else:
                 try:
@@ -696,7 +696,7 @@ def consumption_edit(request, pk):
         "puskesmas/consumption_form.html",
         {
             "form": form,
-            "title": f"Edit Pemakaian {consumption.facility.name} {consumption.bulan:02d}/{consumption.tahun}",
+            "title": f"Ubah Pemakaian {consumption.facility.name} {consumption.bulan:02d}/{consumption.tahun}",
             "is_edit": True,
             "consumption": consumption,
             "subunits": subunits,

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -205,15 +205,15 @@
                 </a>
                 <a href="{% url 'puskesmas:subunit_list' %}"
                     class="sidebar-link {% if request.resolver_match.app_name == 'puskesmas' and request.resolver_match.url_name|slice:':8' == 'subunit_' %}active{% endif %}"
-                    data-label="Subunit Puskesmas"
-                    title="Subunit Puskesmas">
-                    <i class="bi bi-diagram-2"></i><span>Subunit Puskesmas</span>
+                    data-label="Poli/Pustu Puskesmas"
+                    title="Poli/Pustu Puskesmas">
+                    <i class="bi bi-diagram-2"></i><span>Poli/Pustu Puskesmas</span>
                 </a>
                 <a href="{% url 'puskesmas:consumption_list' %}"
                     class="sidebar-link {% if request.resolver_match.app_name == 'puskesmas' and request.resolver_match.url_name|slice:':12' == 'consumption_' %}active{% endif %}"
-                    data-label="Pemakaian Rinci"
-                    title="Pemakaian Rinci">
-                    <i class="bi bi-clipboard-data"></i><span>Pemakaian Rinci</span>
+                    data-label="Input Pemakaian"
+                    title="Input Pemakaian">
+                    <i class="bi bi-clipboard-data"></i><span>Input Pemakaian</span>
                 </a>
                 <a href="{% url 'puskesmas:request_list' %}"
                     class="sidebar-link {% if request.resolver_match.app_name == 'puskesmas' and request.resolver_match.url_name|slice:':8' == 'request_' %}active{% endif %}"

--- a/backend/templates/puskesmas/consumption_detail.html
+++ b/backend/templates/puskesmas/consumption_detail.html
@@ -12,7 +12,7 @@
         </div>
         <div class="d-flex gap-2">
             {% if can_manage %}
-            <a href="{% url 'puskesmas:consumption_edit' consumption.pk %}" class="btn btn-primary">Edit</a>
+            <a href="{% url 'puskesmas:consumption_edit' consumption.pk %}" class="btn btn-primary">Ubah</a>
             <form method="post" action="{% url 'puskesmas:consumption_delete' consumption.pk %}">
                 {% csrf_token %}
                 <button type="submit" class="btn btn-outline-danger">Hapus</button>

--- a/backend/templates/puskesmas/consumption_form.html
+++ b/backend/templates/puskesmas/consumption_form.html
@@ -30,18 +30,17 @@
                 <div class="row g-3">
                     <div class="col-md-4">
                         <label class="form-label fw-semibold">Puskesmas</label>
-                        <input type="text" class="form-control" value="{{ consumption.facility.name }}" readonly>
+                        <input type="text" class="form-control" value="{{ consumption.facility.name }}" title="Puskesmas yang melaporkan pemakaian rinci ini." readonly>
                     </div>
                     <div class="col-md-2">
                         <label class="form-label fw-semibold">Bulan</label>
-                        <input type="text" class="form-control" value="{{ consumption.bulan }}" readonly>
+                        <input type="text" class="form-control" value="{{ consumption.bulan }}" title="Bulan periode pemakaian yang sedang diubah." readonly>
                     </div>
                     <div class="col-md-2">
                         <label class="form-label fw-semibold">Tahun</label>
-                        <input type="text" class="form-control" value="{{ consumption.tahun }}" readonly>
+                        <input type="text" class="form-control" value="{{ consumption.tahun }}" title="Tahun periode pemakaian yang sedang diubah." readonly>
                     </div>
                     <div class="col-md-4">
-                        <label class="form-label fw-semibold">Catatan</label>
                         {{ form.notes|as_crispy_field }}
                     </div>
                 </div>
@@ -51,38 +50,31 @@
                     <div class="row g-3">
                         <div class="col-md-4">
                             <label class="form-label fw-semibold">Puskesmas</label>
-                            <input type="text" class="form-control" value="{{ request.user.facility.name|default:'Belum terhubung ke fasilitas' }}" readonly>
+                            <input type="text" class="form-control" value="{{ request.user.facility.name|default:'Belum terhubung ke fasilitas' }}" title="Puskesmas pemilik dokumen pemakaian rinci ini." readonly>
                             {% if form.facility.errors %}<div class="text-danger small">{{ form.facility.errors }}</div>{% endif %}
                         </div>
                         <div class="col-md-2">
-                            <label class="form-label fw-semibold">Bulan</label>
                             {{ form.bulan|as_crispy_field }}
                         </div>
                         <div class="col-md-2">
-                            <label class="form-label fw-semibold">Tahun</label>
                             {{ form.tahun|as_crispy_field }}
                         </div>
                         <div class="col-md-4">
-                            <label class="form-label fw-semibold">Catatan</label>
                             {{ form.notes|as_crispy_field }}
                         </div>
                     </div>
                     {% else %}
                     <div class="row g-3">
                         <div class="col-md-4">
-                            <label class="form-label fw-semibold">Puskesmas</label>
                             {{ form.facility|as_crispy_field }}
                         </div>
                         <div class="col-md-2">
-                            <label class="form-label fw-semibold">Bulan</label>
                             {{ form.bulan|as_crispy_field }}
                         </div>
                         <div class="col-md-2">
-                            <label class="form-label fw-semibold">Tahun</label>
                             {{ form.tahun|as_crispy_field }}
                         </div>
                         <div class="col-md-4">
-                            <label class="form-label fw-semibold">Catatan</label>
                             {{ form.notes|as_crispy_field }}
                         </div>
                     </div>
@@ -93,11 +85,11 @@
 
         {% if not selected_facility %}
         <div class="alert alert-info">
-            Pilih fasilitas Puskesmas terlebih dahulu untuk memuat kolom subunit.
+            Pilih fasilitas Puskesmas terlebih dahulu untuk memuat kolom Poli/Pustu.
         </div>
         {% elif not subunits %}
         <div class="alert alert-warning">
-            Belum ada subunit aktif untuk {{ selected_facility.name }}. Tambahkan dulu melalui <a href="{% url 'puskesmas:subunit_list' %}">Subunit Puskesmas</a>.
+            Belum ada Poli/Pustu aktif untuk {{ selected_facility.name }}. Tambahkan dulu melalui <a href="{% url 'puskesmas:subunit_list' %}">Poli/Pustu Puskesmas</a>.
         </div>
         {% else %}
         <div class="card mb-4">

--- a/backend/templates/puskesmas/consumption_list.html
+++ b/backend/templates/puskesmas/consumption_list.html
@@ -31,7 +31,7 @@
                 </div>
                 <div class="col-auto d-flex gap-2">
                     <button type="submit" class="btn btn-outline-primary">Cari</button>
-                    <a href="{% url 'puskesmas:consumption_list' %}" class="btn btn-outline-secondary">Reset</a>
+                    <a href="{% url 'puskesmas:consumption_list' %}" class="btn btn-outline-secondary">Atur Ulang</a>
                 </div>
             </form>
 

--- a/backend/templates/puskesmas/subunit_form.html
+++ b/backend/templates/puskesmas/subunit_form.html
@@ -12,7 +12,7 @@
                 {% csrf_token %}
                 <div class="card">
                     <div class="card-header">
-                        <h6 class="mb-0"><i class="bi bi-diagram-2 me-2"></i>Informasi Subunit</h6>
+                        <h6 class="mb-0"><i class="bi bi-diagram-2 me-2"></i>Informasi Poli/Pustu</h6>
                     </div>
                     <div class="card-body">
                         {% if form.non_field_errors %}
@@ -23,7 +23,7 @@
                         {{ form.facility }}
                         <div class="mb-3">
                             <label class="form-label fw-semibold">Puskesmas</label>
-                            <input type="text" class="form-control" value="{{ request.user.facility.name|default:'Belum terhubung ke fasilitas' }}" readonly>
+                            <input type="text" class="form-control" value="{{ request.user.facility.name|default:'Belum terhubung ke fasilitas' }}" title="Puskesmas pemilik data Poli/Pustu ini." readonly>
                             {% if form.facility.errors %}<div class="text-danger small">{{ form.facility.errors }}</div>{% endif %}
                         </div>
                         {% else %}
@@ -32,16 +32,10 @@
 
                         {% if request.user.role == 'PUSKESMAS' %}
                         <div class="mb-3">
-                            <label class="form-label fw-semibold">Nama Subunit</label>
                             {{ form.name|as_crispy_field }}
                         </div>
                         <div class="mb-3">
-                            <label class="form-label fw-semibold">Jenis</label>
                             {{ form.subunit_type|as_crispy_field }}
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label fw-semibold">Urutan Tampil</label>
-                            {{ form.sort_order|as_crispy_field }}
                         </div>
                         <div class="form-check">
                             {{ form.is_active }}
@@ -53,7 +47,7 @@
 
                 <div class="d-flex gap-2 mt-3">
                     <button type="submit" class="btn btn-primary">
-                        <i class="bi bi-save me-1"></i>{% if is_edit %}Simpan Perubahan{% else %}Simpan Subunit{% endif %}
+                        <i class="bi bi-save me-1"></i>{% if is_edit %}Simpan Perubahan{% else %}Simpan Poli/Pustu{% endif %}
                     </button>
                     <a href="{% url 'puskesmas:subunit_list' %}" class="btn btn-outline-secondary">Batal</a>
                 </div>

--- a/backend/templates/puskesmas/subunit_list.html
+++ b/backend/templates/puskesmas/subunit_list.html
@@ -1,19 +1,19 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags %}
 
-{% block title %}Subunit Puskesmas – Healthcare IMS{% endblock %}
-{% block page_title %}Subunit Puskesmas{% endblock %}
+{% block title %}Poli/Pustu Puskesmas – Healthcare IMS{% endblock %}
+{% block page_title %}Poli/Pustu Puskesmas{% endblock %}
 
 {% block content %}
 <div class="container-fluid">
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
         <div>
-            <h4 class="mb-1">Subunit Puskesmas</h4>
-            <p class="text-muted mb-0">Kelola ruang tindakan dan Puskesmas pembantu yang menjadi kolom dinamis pemakaian rinci.</p>
+            <h4 class="mb-1">Poli/Pustu Puskesmas</h4>
+            <p class="text-muted mb-0">Kelola poli dan pustu yang menjadi kolom dinamis pada pemakaian rinci.</p>
         </div>
         {% if request.user.role == 'PUSKESMAS' or request.user.is_superuser %}
         <a href="{% url 'puskesmas:subunit_create' %}" class="btn btn-primary">
-            <i class="bi bi-plus-lg me-1"></i>Tambah Subunit
+            <i class="bi bi-plus-lg me-1"></i>Tambah Poli/Pustu
         </a>
         {% endif %}
     </div>
@@ -22,7 +22,7 @@
         <div class="card-body">
             <form method="get" class="row g-2 mb-3">
                 <div class="col-md-4">
-                    <input type="text" name="q" value="{{ search }}" placeholder="Cari nama subunit / puskesmas..." class="form-control">
+                    <input type="text" name="q" value="{{ search }}" placeholder="Cari nama poli/pustu atau puskesmas..." class="form-control">
                 </div>
                 <div class="col-md-3">
                     <select name="subunit_type" class="form-select">
@@ -34,7 +34,7 @@
                 </div>
                 <div class="col-auto d-flex gap-2">
                     <button type="submit" class="btn btn-outline-primary">Cari</button>
-                    <a href="{% url 'puskesmas:subunit_list' %}" class="btn btn-outline-secondary">Reset</a>
+                    <a href="{% url 'puskesmas:subunit_list' %}" class="btn btn-outline-secondary">Atur Ulang</a>
                 </div>
             </form>
 
@@ -45,7 +45,6 @@
                             <th>Nama</th>
                             <th>Puskesmas</th>
                             <th>Jenis</th>
-                            <th>Urutan</th>
                             <th>Status</th>
                             <th class="text-end">Aksi</th>
                         </tr>
@@ -56,7 +55,6 @@
                             <td class="fw-semibold">{{ subunit.name }}</td>
                             <td>{{ subunit.facility.name }}</td>
                             <td>{{ subunit.get_subunit_type_display }}</td>
-                            <td>{{ subunit.sort_order }}</td>
                             <td>
                                 {% if subunit.is_active %}
                                 <span class="badge text-bg-success">Aktif</span>
@@ -66,7 +64,7 @@
                             </td>
                             <td class="text-end">
                                 {% if request.user.role == 'PUSKESMAS' or request.user.is_superuser %}
-                                <a href="{% url 'puskesmas:subunit_edit' subunit.pk %}" class="btn btn-sm btn-outline-primary">Edit</a>
+                                <a href="{% url 'puskesmas:subunit_edit' subunit.pk %}" class="btn btn-sm btn-outline-primary">Ubah</a>
                                 <form method="post" action="{% url 'puskesmas:subunit_delete' subunit.pk %}" class="d-inline">
                                     {% csrf_token %}
                                     <button type="submit" class="btn btn-sm btn-outline-danger">Hapus</button>
@@ -76,7 +74,7 @@
                         </tr>
                         {% empty %}
                         <tr>
-                            <td colspan="6" class="text-center text-muted py-4">Belum ada subunit Puskesmas.</td>
+                            <td colspan="5" class="text-center text-muted py-4">Belum ada data Poli/Pustu Puskesmas.</td>
                         </tr>
                         {% endfor %}
                     </tbody>


### PR DESCRIPTION
## What changed
- localized the new Puskesmas Poli/Pustu and detailed consumption UI copy into Indonesian
- renamed the sidebar entry from `Pemakaian Rinci` to `Input Pemakaian`
- renamed the reporting-bucket wording in the UI from `Subunit` to `Poli/Pustu`
- added native hover guidance on the Poli/Pustu and detailed consumption inputs using widget `title` attributes
- removed the user-facing `Urutan Tampil` field and list column from the Poli/Pustu flow
- changed Poli/Pustu display ordering to follow `created_at` so entry order is automatic

## Why it changed
The current UI still exposed English wording and a manual ordering field that created unnecessary operator friction. This update makes the screens match the Indonesian product language and simplifies Poli/Pustu maintenance by removing a control users no longer need to manage.

## User impact
- operators now see Indonesian labels and actions across the touched Poli/Pustu and consumption screens
- sidebar navigation now uses `Input Pemakaian`
- Poli/Pustu entries appear in the order they were created instead of requiring manual sort values
- hovering the relevant inputs now shows inline guidance about what each field is used for

## Validation
- `python manage.py test apps.puskesmas.tests.PuskesmasConsumptionFormTests apps.puskesmas.tests.PuskesmasConsumptionViewTests --keepdb`
- `python manage.py check`