### PR TITLE
Fix error handler crash before request.user is attached

### DIFF
--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -1016,6 +1016,18 @@ class ErrorHandlerTests(SimpleTestCase):
         self.assertContains(response, "400", status_code=400)
         self.assertContains(response, "Permintaan tidak dapat diproses", status_code=400)
 
+    def test_bad_request_handles_request_without_user_attribute(self):
+        request = self.factory.get("/bad-request/")
+        request.META["REMOTE_ADDR"] = "127.0.0.1"
+
+        with self.assertLogs("security", level="WARNING") as captured:
+            response = bad_request(request, ValueError("invalid host"))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, "Buka Login", status_code=400)
+        self.assertIn("username=anonymous", captured.output[0])
+        self.assertIn("event=bad_request", captured.output[0])
+
     def test_permission_denied_handler_renders_403_template(self):
         request = self.factory.get("/forbidden/")
         request.user = AnonymousUser()

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -38,7 +38,8 @@ def _get_client_ip(request):
 
 
 def _get_error_fallback(request):
-    if getattr(request.user, "is_authenticated", False):
+    request_user = getattr(request, "user", None)
+    if getattr(request_user, "is_authenticated", False):
         return reverse("dashboard"), "Buka Dashboard"
     return reverse("login"), "Buka Login"
 
@@ -60,9 +61,10 @@ def _build_error_context(request, status_code, title, message, icon, tone, help_
 
 def _log_error_event(logger, level, event, request, status_code, exception=None):
     log_method = getattr(logger, level)
+    request_user = getattr(request, "user", None)
     username = (
-        request.user.username
-        if getattr(request.user, "is_authenticated", False)
+        request_user.username
+        if getattr(request_user, "is_authenticated", False)
         else "anonymous"
     )
     message = (


### PR DESCRIPTION
## Summary
- guard centralized error handling paths when request.user is unavailable
- keep fallback navigation and logging anonymous-safe for early bad-request handling
- add a regression test covering bad_request() with a request object that has no user attribute

## Testing
- cd backend; python manage.py test apps.core.tests.test_core.ErrorHandlerTests.test_bad_request_handles_request_without_user_attribute --keepdb
- cd backend; python manage.py test apps.core.tests.test_core.ErrorHandlerTests --keepdb (fails on a pre-existing 301 vs 404 assertion in test_unmatched_route_uses_custom_404_page_in_debug)
- .\scripts\run-django-test.ps1 -Target apps.core.tests.test_url_consistency -KeepDb

Closes #133
