### PR TITLE
fix(nav): hide puskesmas operations for instalasi farmasi users

### DIFF
--- a/backend/apps/core/context_processors.py
+++ b/backend/apps/core/context_processors.py
@@ -211,7 +211,7 @@ def nav_notifications(request):
             "bi-clipboard-check",
         )
 
-    if puskesmas_scope >= ModuleAccess.Scope.VIEW:
+    if user.is_superuser and puskesmas_scope >= ModuleAccess.Scope.VIEW:
         from apps.puskesmas.models import PuskesmasRequest
 
         count = PuskesmasRequest.objects.filter(

--- a/backend/apps/core/context_processors.py
+++ b/backend/apps/core/context_processors.py
@@ -24,7 +24,7 @@ def nav_notifications(request):
     if not user or not user.is_authenticated:
         return {"nav_notification_count": 0, "nav_notification_items": []}
 
-    from apps.users.access import get_user_module_scope
+    from apps.users.access import get_user_module_scope, is_super_admin
     from apps.users.models import ModuleAccess, User
 
     notification_items = []
@@ -211,7 +211,7 @@ def nav_notifications(request):
             "bi-clipboard-check",
         )
 
-    if user.is_superuser and puskesmas_scope >= ModuleAccess.Scope.VIEW:
+    if is_super_admin(user) and puskesmas_scope >= ModuleAccess.Scope.VIEW:
         from apps.puskesmas.models import PuskesmasRequest
 
         count = PuskesmasRequest.objects.filter(

--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -778,7 +778,23 @@ class DashboardViewTests(TestCase):
         self.assertNotContains(response, "Buat Penerimaan")
         self.assertNotContains(response, "Buat Permintaan Khusus")
         self.assertNotContains(response, "Buat Mutasi Lokasi")
-
+        self.assertNotContains(response, "Konfirmasi Penerimaan")
+        self.assertNotContains(response, "Poli/Pustu Puskesmas")
+        self.assertNotContains(response, "Input Pemakaian")
+        self.assertNotContains(response, "Permintaan Barang")
+    def test_superuser_dashboard_keeps_puskesmas_sidebar_visible(self):
+        admin_user = User.objects.create_superuser(
+            username="dashboard-admin-puskesmas",
+            email="dashboard-admin-puskesmas@example.com",
+            password="TestPassword123!",
+        )
+        self.client.force_login(admin_user)
+        response = self.client.get(reverse("dashboard"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Konfirmasi Penerimaan")
+        self.assertContains(response, "Poli/Pustu Puskesmas")
+        self.assertContains(response, "Input Pemakaian")
+        self.assertContains(response, "Permintaan Barang")
 
 @override_settings(SECURE_SSL_REDIRECT=False)
 class ErrorPageTemplateTests(TestCase):
@@ -1356,7 +1372,7 @@ class NavNotificationsContextProcessorTests(TestCase):
             any(item["label"] == "Penerimaan" for item in context["nav_notification_items"])
         )
 
-    def test_admin_umum_gets_puskesmas_request_notifications_with_view_scope(self):
+    def test_admin_umum_does_not_get_puskesmas_request_notifications_when_sidebar_is_hidden(self):
         admin_umum = User.objects.create_user(
             username="nav-admin-umum-puskesmas",
             password="TestPassword123!",
@@ -1380,14 +1396,11 @@ class NavNotificationsContextProcessorTests(TestCase):
         request.user = admin_umum
         context = nav_notifications(request)
 
-        self.assertTrue(
-            any(
-                item["label"] == "Permintaan Puskesmas" and item["count"] == 1
-                for item in context["nav_notification_items"]
-            )
+        self.assertFalse(
+            any(item["label"] == "Permintaan Puskesmas" for item in context["nav_notification_items"])
         )
 
-    def test_gudang_gets_puskesmas_request_notifications_with_view_scope(self):
+    def test_gudang_does_not_get_puskesmas_request_notifications_when_sidebar_is_hidden(self):
         gudang = User.objects.create_user(
             username="nav-gudang-puskesmas",
             password="TestPassword123!",
@@ -1409,11 +1422,8 @@ class NavNotificationsContextProcessorTests(TestCase):
         request.user = gudang
         context = nav_notifications(request)
 
-        self.assertTrue(
-            any(
-                item["label"] == "Permintaan Puskesmas" and item["count"] == 1
-                for item in context["nav_notification_items"]
-            )
+        self.assertFalse(
+            any(item["label"] == "Permintaan Puskesmas" for item in context["nav_notification_items"])
         )
 
     def test_explicit_none_scope_hides_puskesmas_request_notifications(self):

--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -782,6 +782,7 @@ class DashboardViewTests(TestCase):
         self.assertNotContains(response, "Poli/Pustu Puskesmas")
         self.assertNotContains(response, "Input Pemakaian")
         self.assertNotContains(response, "Permintaan Barang")
+
     def test_superuser_dashboard_keeps_puskesmas_sidebar_visible(self):
         admin_user = User.objects.create_superuser(
             username="dashboard-admin-puskesmas",
@@ -790,6 +791,24 @@ class DashboardViewTests(TestCase):
         )
         self.client.force_login(admin_user)
         response = self.client.get(reverse("dashboard"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Konfirmasi Penerimaan")
+        self.assertContains(response, "Poli/Pustu Puskesmas")
+        self.assertContains(response, "Input Pemakaian")
+        self.assertContains(response, "Permintaan Barang")
+
+    def test_legacy_admin_role_dashboard_keeps_puskesmas_sidebar_visible(self):
+        admin_user = User.objects.create_superuser(
+            username="dashboard-legacy-admin-puskesmas",
+            email="dashboard-legacy-admin-puskesmas@example.com",
+            password="TestPassword123!",
+        )
+        User.objects.filter(pk=admin_user.pk).update(is_superuser=False, is_staff=False)
+        admin_user.refresh_from_db()
+
+        self.client.force_login(admin_user)
+        response = self.client.get(reverse("dashboard"))
+
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Konfirmasi Penerimaan")
         self.assertContains(response, "Poli/Pustu Puskesmas")
@@ -1424,6 +1443,41 @@ class NavNotificationsContextProcessorTests(TestCase):
 
         self.assertFalse(
             any(item["label"] == "Permintaan Puskesmas" for item in context["nav_notification_items"])
+        )
+
+    def test_legacy_admin_role_keeps_puskesmas_request_notifications(self):
+        admin_user = User.objects.create_superuser(
+            username="nav-legacy-admin-puskesmas",
+            email="nav-legacy-admin-puskesmas@example.com",
+            password="TestPassword123!",
+        )
+        User.objects.filter(pk=admin_user.pk).update(is_superuser=False, is_staff=False)
+        admin_user.refresh_from_db()
+        self._set_scope(
+            admin_user,
+            ModuleAccess.Module.PUSKESMAS,
+            ModuleAccess.Scope.MANAGE,
+        )
+        facility = Facility.objects.create(
+            code="PKM-NAV-ADM",
+            name="Puskesmas Legacy Admin",
+            facility_type=Facility.FacilityType.PUSKESMAS,
+        )
+        PuskesmasRequest.objects.create(
+            facility=facility,
+            created_by=admin_user,
+            status=PuskesmasRequest.Status.SUBMITTED,
+        )
+
+        request = self.factory.get("/")
+        request.user = admin_user
+        context = nav_notifications(request)
+
+        self.assertTrue(
+            any(
+                item["label"] == "Permintaan Puskesmas"
+                for item in context["nav_notification_items"]
+            )
         )
 
     def test_explicit_none_scope_hides_puskesmas_request_notifications(self):

--- a/backend/apps/lplpo/views.py
+++ b/backend/apps/lplpo/views.py
@@ -20,7 +20,7 @@ from apps.distribution.models import Distribution, DistributionItem
 from apps.distribution.services import assign_default_distribution_staff
 from apps.items.models import Facility, Item
 from apps.stock.models import Stock
-from apps.users.access import has_module_permission, has_module_scope
+from apps.users.access import has_module_permission, has_module_scope, is_super_admin
 from apps.users.models import ModuleAccess, User
 
 from .forms import (
@@ -47,10 +47,6 @@ from .xlsx_io import apply_lplpo_workbook_import, export_lplpo_workbook
 
 logger = logging.getLogger(__name__)
 security_logger = logging.getLogger("security")
-
-
-def _is_super_admin(user):
-    return bool(getattr(user, "is_superuser", False)) or getattr(user, "role", None) == User.Role.ADMIN
 
 
 def _refresh_editable_lplpo_from_puskesmas_sources(lplpo_obj):
@@ -154,7 +150,7 @@ def _get_cross_facility_queue_statuses(user):
 
 
 def _get_required_facility(user):
-    if _is_super_admin(user):
+    if is_super_admin(user):
         return None
 
     facility = getattr(user, "facility", None)
@@ -167,7 +163,7 @@ def _check_facility_access(request, lplpo_obj, *, route_kind):
     """
     Enforce per-facility access for facility-bound roles.
     """
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         return None
 
     if _can_access_lplpo_cross_facility(
@@ -216,7 +212,7 @@ def _can_create_manual_lplpo_distribution(user):
 
 def _check_puskesmas_creator_access(request):
     """Restrict create flow to PUSKESMAS operators and super admin."""
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         return
     if request.user.role != User.Role.PUSKESMAS:
         raise PermissionDenied("Hanya operator Puskesmas yang dapat membuat LPLPO.")
@@ -224,7 +220,7 @@ def _check_puskesmas_creator_access(request):
 
 def _check_puskesmas_draft_action_access(request):
     """Restrict draft LPLPO mutations to PUSKESMAS operators and super admin."""
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         return
     if request.user.role != User.Role.PUSKESMAS:
         raise PermissionDenied(
@@ -238,7 +234,7 @@ def _get_submission_month_choices():
 
 def _resolve_lplpo_create_facility(form, user):
     facility = getattr(user, "facility", None)
-    if _is_super_admin(user) or not facility:
+    if is_super_admin(user) or not facility:
         facility = form.cleaned_data.get("facility")
     return facility
 
@@ -342,7 +338,7 @@ def _get_filtered_lplpo_queryset(request, *, submitted_only=True):
     if submitted_year:
         queryset = queryset.filter(submitted_at__year=submitted_year)
 
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         pass
     elif _can_access_lplpo_cross_facility(
         request.user,
@@ -377,7 +373,7 @@ def lplpo_list(request):
 
     queryset, filter_context = _get_filtered_lplpo_queryset(
         request,
-        submitted_only=not _is_super_admin(request.user),
+        submitted_only=not is_super_admin(request.user),
     )
 
     paginator = Paginator(queryset, 25)
@@ -390,7 +386,7 @@ def lplpo_list(request):
             "lplpos": page,
             **filter_context,
             "is_all": True,
-            "can_manage_all_lplpo": _is_super_admin(request.user),
+            "can_manage_all_lplpo": is_super_admin(request.user),
             "can_create_manual_lplpo_distribution": _can_create_manual_lplpo_distribution(
                 request.user
             ),
@@ -571,7 +567,7 @@ def lplpo_create(request):
 
                 LPLPOItem.objects.bulk_create(lplpo_items)
 
-            if _is_super_admin(request.user):
+            if is_super_admin(request.user):
                 logger.info(
                     "super_admin_created_lplpo",
                     extra={
@@ -601,7 +597,7 @@ def api_prefill_penerimaan(request):
         return JsonResponse({"detail": "Method not allowed."}, status=405)
 
     facility = None
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         facility_id = request.GET.get("facility")
         if facility_id:
             facility = get_object_or_404(
@@ -699,7 +695,7 @@ def lplpo_detail(request, pk):
             "items": items,
             "can_review": can_review,
             "can_approve": can_approve,
-            "can_manage_draft": _is_super_admin(request.user)
+            "can_manage_draft": is_super_admin(request.user)
             or request.user.role == User.Role.PUSKESMAS,
         },
     )
@@ -822,7 +818,7 @@ def lplpo_edit(request, pk):
                     ],
                 )
 
-            if _is_super_admin(request.user):
+            if is_super_admin(request.user):
                 logger.info(
                     "super_admin_updated_lplpo_draft",
                     extra={
@@ -1099,7 +1095,7 @@ def lplpo_submit(request, pk):
             ]
         )
 
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         logger.info(
             "super_admin_submitted_lplpo",
             extra={
@@ -1546,7 +1542,7 @@ def lplpo_delete(request, pk):
     doc_number = lplpo_obj.document_number
     facility_id = lplpo_obj.facility_id
     lplpo_obj.delete()
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         logger.info(
             "super_admin_deleted_lplpo",
             extra={

--- a/backend/apps/puskesmas/views.py
+++ b/backend/apps/puskesmas/views.py
@@ -18,7 +18,7 @@ from apps.core.rate_limits import (
 from apps.distribution.models import Distribution, DistributionItem
 from apps.distribution.services import assign_default_distribution_staff
 from apps.lplpo.models import LPLPO
-from apps.users.access import has_module_permission, has_module_scope
+from apps.users.access import has_module_permission, has_module_scope, is_super_admin
 from apps.users.models import ModuleAccess, User
 from apps.items.models import Facility, Item
 
@@ -57,12 +57,8 @@ from .services import (
 logger = logging.getLogger(__name__)
 
 
-def _is_super_admin(user):
-    return bool(getattr(user, "is_superuser", False)) or getattr(user, "role", None) == User.Role.ADMIN
-
-
 def _get_required_facility(user):
-    if _is_super_admin(user):
+    if is_super_admin(user):
         return None
 
     facility = getattr(user, "facility", None)
@@ -77,7 +73,7 @@ def _can_review_request(user):
     if not getattr(user, "is_authenticated", False):
         return False
 
-    if _is_super_admin(user):
+    if is_super_admin(user):
         return True
 
     if getattr(user, "role", None) == "PUSKESMAS":
@@ -96,7 +92,7 @@ def _can_manage_request(user, req=None):
     if not getattr(user, "is_authenticated", False):
         return False
 
-    if _is_super_admin(user):
+    if is_super_admin(user):
         return True
 
     facility = getattr(user, "facility", None)
@@ -129,7 +125,7 @@ def _can_reset_request_to_draft(user, req):
 
 
 def _check_request_facility_access(request, req):
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         return None
 
     facility = _get_required_facility(request.user)
@@ -146,7 +142,7 @@ def _check_puskesmas_request_creator_access(request):
 
 
 def _check_puskesmas_receiving_creator_access(request):
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         return None
     if getattr(request.user, "role", None) != User.Role.PUSKESMAS:
         raise_receiving_creator_denied()
@@ -154,7 +150,7 @@ def _check_puskesmas_receiving_creator_access(request):
 
 
 def _check_receiving_facility_access(request, receipt_confirmation):
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         return None
 
     facility = _get_required_facility(request.user)
@@ -166,7 +162,7 @@ def _check_receiving_facility_access(request, receipt_confirmation):
 
 
 def _check_subunit_facility_access(request, subunit):
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         return None
 
     facility = _get_required_facility(request.user)
@@ -176,7 +172,7 @@ def _check_subunit_facility_access(request, subunit):
 
 
 def _check_consumption_facility_access(request, consumption):
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         return None
 
     facility = _get_required_facility(request.user)
@@ -186,7 +182,7 @@ def _check_consumption_facility_access(request, consumption):
 
 
 def _check_puskesmas_consumption_creator_access(request):
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         return None
     if getattr(request.user, "role", None) != User.Role.PUSKESMAS:
         raise_consumption_creator_denied()
@@ -197,7 +193,7 @@ def _get_candidate_consumption_facility(request, *, consumption=None):
     if consumption is not None:
         return consumption.facility
 
-    if not _is_super_admin(request.user):
+    if not is_super_admin(request.user):
         return _get_required_facility(request.user)
 
     facility_id = request.POST.get("facility") or request.GET.get("facility")
@@ -290,7 +286,7 @@ def _get_receiving_distribution_queryset(user, *, include_pk=None):
     else:
         queryset = queryset.filter(receipt_confirmation__isnull=True)
 
-    if not _is_super_admin(user):
+    if not is_super_admin(user):
         facility = _get_required_facility(user)
         queryset = queryset.filter(facility_id=facility.pk)
 
@@ -451,7 +447,7 @@ def subunit_list(request):
         "facility__name", "created_at", "name"
     )
 
-    if not _is_super_admin(request.user):
+    if not is_super_admin(request.user):
         facility = _get_required_facility(request.user)
         queryset = queryset.filter(facility_id=facility.pk)
 
@@ -593,7 +589,7 @@ def consumption_list(request):
         "facility", "created_by", "updated_by"
     ).order_by("-tahun", "-bulan", "facility__name")
 
-    if not _is_super_admin(request.user):
+    if not is_super_admin(request.user):
         facility = _get_required_facility(request.user)
         queryset = queryset.filter(facility_id=facility.pk)
 
@@ -643,7 +639,7 @@ def consumption_create(request):
         )
         if form.is_valid():
             should_load_matrix = (
-                _is_super_admin(request.user)
+                is_super_admin(request.user)
                 and request.POST.get("action") == "load_matrix"
             )
             if should_load_matrix:
@@ -774,7 +770,7 @@ def consumption_detail(request, pk):
             "subunits": subunits,
             "matrix_rows": matrix_rows,
             "grand_total": grand_total,
-            "can_manage": _is_super_admin(request.user)
+            "can_manage": is_super_admin(request.user)
             or request.user.role == User.Role.PUSKESMAS,
         },
     )
@@ -937,7 +933,7 @@ def receiving_list(request):
         "facility", "created_by", "distribution"
     ).order_by("-received_date", "-created_at")
 
-    if not _is_super_admin(request.user):
+    if not is_super_admin(request.user):
         facility = _get_required_facility(request.user)
         queryset = queryset.filter(facility_id=facility.pk)
 
@@ -1089,7 +1085,7 @@ def receiving_detail(request, pk):
         "item__program",
         "distribution_item",
     )
-    can_manage = _is_super_admin(request.user) or request.user.role == User.Role.PUSKESMAS
+    can_manage = is_super_admin(request.user) or request.user.role == User.Role.PUSKESMAS
 
     locked_lplpo = LPLPO.objects.filter(
         facility=receipt_confirmation.facility,
@@ -1373,7 +1369,7 @@ def request_list(request):
         "facility", "created_by", "program"
     ).order_by("-request_date")
 
-    if not _is_super_admin(request.user):
+    if not is_super_admin(request.user):
         facility = _get_required_facility(request.user)
         queryset = queryset.filter(facility_id=facility.pk)
 
@@ -1881,7 +1877,7 @@ def puskesmas_report_penerimaan(request):
 
     # Facility chooser for super admin
     all_facilities = []
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         all_facilities = FacilityModel.objects.filter(
             facility_type=FacilityModel.FacilityType.PUSKESMAS, is_active=True
         ).order_by("name")
@@ -1986,7 +1982,7 @@ def puskesmas_report_pemakaian(request):
 
     # Facility chooser for super admin
     all_facilities = []
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         all_facilities = FacilityModel.objects.filter(
             facility_type=FacilityModel.FacilityType.PUSKESMAS, is_active=True
         ).order_by("name")
@@ -2195,7 +2191,7 @@ def puskesmas_report_persediaan(request):
 
     # Facility chooser for super admin
     all_facilities = []
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         all_facilities = FacilityModel.objects.filter(
             facility_type=FacilityModel.FacilityType.PUSKESMAS, is_active=True
         ).order_by("name")
@@ -2385,7 +2381,7 @@ def puskesmas_report_rekap_persediaan(request):
             )
 
     all_facilities = []
-    if _is_super_admin(request.user):
+    if is_super_admin(request.user):
         all_facilities = FacilityModel.objects.filter(
             facility_type=FacilityModel.FacilityType.PUSKESMAS, is_active=True
         ).order_by("name")

--- a/backend/apps/users/access.py
+++ b/backend/apps/users/access.py
@@ -112,6 +112,12 @@ def get_user_module_scope(user: User, module: str) -> int:
     return default_scope_for_role(getattr(user, "role", ""), module)
 
 
+def is_super_admin(user: User) -> bool:
+    return bool(getattr(user, "is_superuser", False)) or (
+        getattr(user, "role", None) == User.Role.ADMIN
+    )
+
+
 def has_module_scope(user: User, module: str, min_scope: int) -> bool:
     if not getattr(user, "is_authenticated", False):
         return False

--- a/backend/apps/users/context_processors.py
+++ b/backend/apps/users/context_processors.py
@@ -1,4 +1,4 @@
-from .access import has_module_scope
+from .access import has_module_scope, is_super_admin
 from .models import ModuleAccess
 
 
@@ -19,6 +19,7 @@ def access_flags(request):
             "can_view_reports": False,
             "can_view_puskesmas": False,
             "can_view_lplpo": False,
+            "is_super_admin_user": False,
         }
 
     return {
@@ -61,4 +62,5 @@ def access_flags(request):
         "can_view_lplpo": has_module_scope(
             user, ModuleAccess.Module.LPLPO, ModuleAccess.Scope.VIEW
         ),
+        "is_super_admin_user": is_super_admin(user),
     }

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -202,7 +202,7 @@
                 {% endif %}
                 {% endif %}
 
-                {% if request.user.is_superuser or request.user.role == 'PUSKESMAS' %}
+                {% if is_super_admin_user or request.user.role == 'PUSKESMAS' %}
                 <div class="sidebar-section-title">Puskesmas</div>
                 {% if can_view_puskesmas %}
                 <a href="{% url 'puskesmas:receiving_list' %}"

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -202,7 +202,7 @@
                 {% endif %}
                 {% endif %}
 
-                {% if can_view_puskesmas or can_view_lplpo and request.user.role == 'PUSKESMAS' %}
+                {% if request.user.is_superuser or request.user.role == 'PUSKESMAS' %}
                 <div class="sidebar-section-title">Puskesmas</div>
                 {% if can_view_puskesmas %}
                 <a href="{% url 'puskesmas:receiving_list' %}"


### PR DESCRIPTION
Hide the operator-facing Puskesmas sidebar section for non-superuser, non-PUSKESMAS users while keeping the separate LPLPO distribution entry under Pengeluaran intact.

Also stop emitting the Permintaan Puskesmas navbar notification for non-superusers so hidden operational pages are not still exposed through the bell dropdown.

Validation: targeted Django tests passed for dashboard sidebar visibility, stock sidebar visibility, and the non-PUSKESMAS notification regressions. Broader core-suite failures remain environment-related and unrelated to this change.

# Pull Request

## Summary

-

## Testing

- [ ] Tests run locally (or explain why not)

## Documentation and release checklist

- [ ] Docs updated when models/routes/settings/scripts changed (`README.md`, `AGENTS.md`, `SYSTEM_MODEL.md`, `docs/developer_guide.md`, `backend/seed/README.md` as needed)
- [ ] If release-impacting, `VERSION` and `CHANGELOG.md` are updated in this PR
