### PR TITLE
[codex] Preserve typeahead item selections on receiving submit

### DIFF
--- a/backend/static/js/app.js
+++ b/backend/static/js/app.js
@@ -163,9 +163,57 @@ function initTypeaheadSelects() {
             updateDropdownPosition();
         };
 
+        const getSelectedOption = () =>
+            select.selectedOptions?.[0] || select.options[select.selectedIndex] || null;
+
+        const normalizeTypeaheadValue = (value) => (value || '').trim().toLocaleLowerCase();
+
         const syncInputFromSelect = () => {
-            const selectedOption = select.selectedOptions?.[0] || select.options[select.selectedIndex] || null;
+            const selectedOption = getSelectedOption();
             input.value = selectedOption && selectedOption.value ? selectedOption.text : '';
+        };
+
+        const findExactOptionMatch = (query) => {
+            const normalizedQuery = normalizeTypeaheadValue(query);
+            if (!normalizedQuery) {
+                return null;
+            }
+
+            return optionsSnapshot.find((opt) => (
+                !opt.disabled &&
+                opt.value &&
+                normalizeTypeaheadValue(opt.text) === normalizedQuery
+            )) || null;
+        };
+
+        const syncSelectFromInput = () => {
+            const normalizedInput = normalizeTypeaheadValue(input.value);
+            const selectedOption = getSelectedOption();
+            const normalizedSelectedText = selectedOption && selectedOption.value
+                ? normalizeTypeaheadValue(selectedOption.text)
+                : '';
+
+            if (!normalizedInput) {
+                if (select.value) {
+                    select.value = '';
+                    select.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+                return;
+            }
+
+            const exactMatch = findExactOptionMatch(input.value);
+            if (exactMatch) {
+                if (select.value !== exactMatch.value) {
+                    select.value = exactMatch.value;
+                    select.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+                return;
+            }
+
+            if (select.value && normalizedSelectedText !== normalizedInput) {
+                select.value = '';
+                select.dispatchEvent(new Event('change', { bubbles: true }));
+            }
         };
 
         const renderOptions = (query) => {
@@ -247,6 +295,9 @@ function initTypeaheadSelects() {
             renderOptions(input.value);
             setActiveIndex(0);
         });
+        input.addEventListener('blur', () => {
+            window.setTimeout(syncSelectFromInput, 0);
+        });
         input.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {
                 closeDropdown();
@@ -273,6 +324,13 @@ function initTypeaheadSelects() {
         document.addEventListener('click', (e) => {
             if (!wrapper.contains(e.target) && !dropdown.contains(e.target)) closeDropdown();
         });
+
+        const form = select.form;
+        if (form) {
+            form.addEventListener('submit', () => {
+                syncSelectFromInput();
+            });
+        }
 
         // If select changes programmatically, reflect in input
         select.addEventListener('change', () => {

--- a/backend/static/js/app.js
+++ b/backend/static/js/app.js
@@ -216,6 +216,8 @@ function initTypeaheadSelects() {
             }
         };
 
+        select.syncTypeaheadSelection = syncSelectFromInput;
+
         const renderOptions = (query) => {
             const q = (query || '').trim().toLowerCase();
             dropdown.innerHTML = '';
@@ -324,13 +326,6 @@ function initTypeaheadSelects() {
         document.addEventListener('click', (e) => {
             if (!wrapper.contains(e.target) && !dropdown.contains(e.target)) closeDropdown();
         });
-
-        const form = select.form;
-        if (form) {
-            form.addEventListener('submit', () => {
-                syncSelectFromInput();
-            });
-        }
 
         // If select changes programmatically, reflect in input
         select.addEventListener('change', () => {

--- a/backend/static/js/item-picker-table.js
+++ b/backend/static/js/item-picker-table.js
@@ -148,6 +148,10 @@ function bindItemPickerTable(form) {
                 return;
             }
 
+            if (typeof item.syncTypeaheadSelection === 'function') {
+                item.syncTypeaheadSelection();
+            }
+
             clearRowError(row);
 
             if (!item.value) {

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -556,7 +556,7 @@
     {% endif %}
 
     <script src="{% static 'vendor/bootstrap/js/bootstrap.bundle.min.js' %}?v={{ app_version }}-20260416"></script>
-    <script src="{% static 'js/app.js' %}?v={{ app_version }}-20260416"></script>
+    <script src="{% static 'js/app.js' %}?v={{ app_version }}-20260630a"></script>
     <script src="{% static 'js/confirm-actions.js' %}?v={{ app_version }}-20260416"></script>
     {% block extra_js %}{% endblock %}
 </body>

--- a/backend/templates/distribution/distribution_form.html
+++ b/backend/templates/distribution/distribution_form.html
@@ -440,7 +440,7 @@
 
 {% block extra_js %}
 {% load static %}
-<script src="{% static 'js/item-picker-table.js' %}?v={{ app_version }}-20260506a"></script>
+<script src="{% static 'js/item-picker-table.js' %}?v={{ app_version }}-20260701a"></script>
 <script src="{% static 'js/distribution-form.js' %}?v={{ app_version }}-20260504a"></script>
 {% if document_number_warning_enabled %}
 <script>

--- a/backend/templates/expired/expired_form.html
+++ b/backend/templates/expired/expired_form.html
@@ -137,5 +137,5 @@
 
 {% block extra_js %}
 {% load static %}
-<script src="{% static 'js/item-picker-table.js' %}?v={{ app_version }}-20260506a"></script>
+<script src="{% static 'js/item-picker-table.js' %}?v={{ app_version }}-20260701a"></script>
 {% endblock %}

--- a/backend/templates/receiving/receiving_form.html
+++ b/backend/templates/receiving/receiving_form.html
@@ -259,6 +259,6 @@
 
 {% block extra_js %}
 {% load static %}
-<script src="{% static 'js/item-picker-table.js' %}?v={{ app_version }}-20260506a"></script>
+<script src="{% static 'js/item-picker-table.js' %}?v={{ app_version }}-20260701a"></script>
 <script src="{% static 'js/quick-create.js' %}"></script>
 {% endblock %}

--- a/backend/templates/receiving/receiving_plan_form.html
+++ b/backend/templates/receiving/receiving_plan_form.html
@@ -234,6 +234,6 @@
 
 {% block extra_js %}
 {% load static %}
-<script src="{% static 'js/item-picker-table.js' %}?v={{ app_version }}-20260506a"></script>
+<script src="{% static 'js/item-picker-table.js' %}?v={{ app_version }}-20260701a"></script>
 <script src="{% static 'js/quick-create.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- reconcile typed typeahead text back into the hidden select on blur and form submit
- clear stale hidden select values when the visible text no longer matches the selected option
- bump the shared app.js cache-bust so browsers fetch the fixed widget code

## Problem
The receiving item picker uses a visible text input backed by a hidden select. Users could type an exact item name, see the field as filled, and still submit an empty items-N-item value if they did not explicitly click a suggestion. That produced a confusing required-field error even though the UI looked populated.

## Testing
- 
ode --check backend/static/js/app.js
- local logic check for exact-match selection, stale-value clearing, and blank-input clearing

## Notes
- PR #150 was already merged; this is the follow-up PR for the one additional UI commit on the same branch.