### PR TITLE
[codex] fix receiving CSV import quantity validation (#152)

### DIFF
--- a/SYSTEM_MODEL.md
+++ b/SYSTEM_MODEL.md
@@ -474,7 +474,7 @@ From `backend/config/settings.py`:
 Defined in `backend/apps/receiving/admin.py` (`ReceivingAdmin.import_csv_view`):
 
 - Endpoint: `/admin/receiving/receiving/import-csv/`
-- Required columns: `document_number`, `receiving_date`, `item_code`, `sumber_dana_code`, `location_code`, `quantity`
+- Required columns: `document_number`, `receiving_date`, `item_code`, `sumber_dana_code`, `location_code`, `quantity` (`quantity` must be a finite decimal greater than `0`)
 - Optional columns: `receiving_type` (defaults to `GRANT`), `supplier_code`, `batch_lot`, `expiry_date`, `unit_price`
 - Rows are grouped by `document_number`; first-row supplier and header values seed the parent `Receiving`
 - Row-level `sumber_dana_code` and `location_code` may override the first-row values for each line item
@@ -483,7 +483,7 @@ Defined in `backend/apps/receiving/admin.py` (`ReceivingAdmin.import_csv_view`):
   - `YYYY-MM-DD`
   - `DD-MM-YYYY`
   - `DD/MM/YY`
-- Decimal parser supports comma decimal separator
+- Decimal parser supports comma decimal separator and rejects blank, `0`, negative, `NaN`, and `Infinity` quantities
 - Runs in `@transaction.atomic`
 
 ## 8) Documentation Maintenance Policy
@@ -498,3 +498,4 @@ If model fields, routes, settings, permission logic, or import behavior change:
    - `/django/django`
    - `/websites/django-import-export_readthedocs_io_en`
    - `/jazzband/django-axes`
+

--- a/backend/apps/receiving/admin.py
+++ b/backend/apps/receiving/admin.py
@@ -385,9 +385,11 @@ class ReceivingAdmin(admin.ModelAdmin):
                     ) from exc
 
                 quantity = self._parse_decimal(
-                    row.get("quantity", "0"),
+                    row.get("quantity", ""),
                     row_num=row_num,
                     field_name="quantity",
+                    required=True,
+                    must_be_positive=True,
                 )
                 unit_price = self._parse_decimal(
                     row.get("unit_price", "0"),
@@ -515,11 +517,33 @@ class ReceivingAdmin(admin.ModelAdmin):
         )
 
     @staticmethod
-    def _parse_decimal(value, row_num=None, field_name="nilai"):
+    def _parse_decimal(
+        value,
+        row_num=None,
+        field_name="nilai",
+        *,
+        required=False,
+        must_be_positive=False,
+    ):
         """Parse decimal value, handling comma as decimal separator."""
+        raw_value = (value or "").strip()
+        if required and not raw_value:
+            if row_num is not None:
+                raise ValueError(f"Baris {row_num}: {field_name} wajib diisi")
+            raise ValueError(f"{field_name} wajib diisi")
+
         try:
-            return parse_decimal_input(value, field_label=field_name)
+            decimal_value = parse_decimal_input(value, field_label=field_name)
         except forms.ValidationError as exc:
             if row_num is not None:
                 raise ValueError(f"Baris {row_num}: {exc.messages[0]}") from exc
             raise ValueError(exc.messages[0]) from exc
+
+        if must_be_positive and decimal_value <= 0:
+            message = f"{field_name} harus lebih dari 0"
+            if row_num is not None:
+                raise ValueError(f"Baris {row_num}: {message}")
+            raise ValueError(message)
+
+        return decimal_value
+

--- a/backend/apps/receiving/tests.py
+++ b/backend/apps/receiving/tests.py
@@ -112,7 +112,7 @@ class ReceivingCSVImportTest(TestCase):
         csv_content = (
             "document_number,receiving_type,receiving_date,supplier_code,sumber_dana_code,"
             "location_code,item_code,quantity,batch_lot,expiry_date,unit_price\n"
-            "RCV-2026-00001,GRANT,12/03/2026,,APBD,GUDANG,ITM-TEST-0001,,,,\n"
+            "RCV-2026-00001,GRANT,12/03/2026,,APBD,GUDANG,ITM-TEST-0001,10,,,\n"
         )
 
         result = self.admin._process_csv(self._csv_file(csv_content), self.user)
@@ -123,14 +123,59 @@ class ReceivingCSVImportTest(TestCase):
         self.assertEqual(result["transactions"], 1)
 
         receiving_item = ReceivingItem.objects.get()
-        self.assertEqual(receiving_item.quantity, Decimal("0"))
+        self.assertEqual(receiving_item.quantity, Decimal("10"))
         self.assertEqual(receiving_item.unit_price, Decimal("0"))
         self.assertEqual(receiving_item.batch_lot, "SALDO-0002")
         self.assertEqual(receiving_item.expiry_date, date(2099, 12, 31))
 
         stock = Stock.objects.get()
-        self.assertEqual(stock.quantity, Decimal("0"))
+        self.assertEqual(stock.quantity, Decimal("10"))
         self.assertEqual(stock.batch_lot, "SALDO-0002")
+
+    def test_process_csv_rejects_blank_quantity(self):
+        csv_content = (
+            "document_number,receiving_type,receiving_date,supplier_code,sumber_dana_code,"
+            "location_code,item_code,quantity,batch_lot,expiry_date,unit_price\n"
+            "RCV-2026-00001,GRANT,12/03/2026,,APBD,GUDANG,ITM-TEST-0001,,B-001,01/01/2030,1000\n"
+        )
+
+        with self.assertRaisesMessage(ValueError, "Baris 2: quantity wajib diisi"):
+            self.admin._process_csv(self._csv_file(csv_content), self.user)
+
+        self.assertEqual(Receiving.objects.count(), 0)
+        self.assertEqual(ReceivingItem.objects.count(), 0)
+        self.assertEqual(Stock.objects.count(), 0)
+        self.assertEqual(Transaction.objects.count(), 0)
+
+    def test_process_csv_rejects_zero_quantity(self):
+        csv_content = (
+            "document_number,receiving_type,receiving_date,supplier_code,sumber_dana_code,"
+            "location_code,item_code,quantity,batch_lot,expiry_date,unit_price\n"
+            "RCV-2026-00001,GRANT,12/03/2026,,APBD,GUDANG,ITM-TEST-0001,0,B-001,01/01/2030,1000\n"
+        )
+
+        with self.assertRaisesMessage(ValueError, "Baris 2: quantity harus lebih dari 0"):
+            self.admin._process_csv(self._csv_file(csv_content), self.user)
+
+        self.assertEqual(Receiving.objects.count(), 0)
+        self.assertEqual(ReceivingItem.objects.count(), 0)
+        self.assertEqual(Stock.objects.count(), 0)
+        self.assertEqual(Transaction.objects.count(), 0)
+
+    def test_process_csv_rejects_negative_quantity(self):
+        csv_content = (
+            "document_number,receiving_type,receiving_date,supplier_code,sumber_dana_code,"
+            "location_code,item_code,quantity,batch_lot,expiry_date,unit_price\n"
+            "RCV-2026-00001,GRANT,12/03/2026,,APBD,GUDANG,ITM-TEST-0001,-5,B-001,01/01/2030,1000\n"
+        )
+
+        with self.assertRaisesMessage(ValueError, "Baris 2: quantity harus lebih dari 0"):
+            self.admin._process_csv(self._csv_file(csv_content), self.user)
+
+        self.assertEqual(Receiving.objects.count(), 0)
+        self.assertEqual(ReceivingItem.objects.count(), 0)
+        self.assertEqual(Stock.objects.count(), 0)
+        self.assertEqual(Transaction.objects.count(), 0)
 
     def test_process_csv_handles_missing_cell_without_strip_crash(self):
         csv_content = (
@@ -166,6 +211,11 @@ class ReceivingCSVImportTest(TestCase):
         ):
             self.admin._process_csv(self._csv_file(csv_content), self.user)
 
+        self.assertEqual(Receiving.objects.count(), 0)
+        self.assertEqual(ReceivingItem.objects.count(), 0)
+        self.assertEqual(Stock.objects.count(), 0)
+        self.assertEqual(Transaction.objects.count(), 0)
+
     def test_process_csv_rejects_nan_decimal(self):
         csv_content = (
             "document_number,receiving_type,receiving_date,supplier_code,sumber_dana_code,"
@@ -177,6 +227,11 @@ class ReceivingCSVImportTest(TestCase):
             ValueError, "Baris 2: quantity tidak boleh NaN atau Infinity"
         ):
             self.admin._process_csv(self._csv_file(csv_content), self.user)
+
+        self.assertEqual(Receiving.objects.count(), 0)
+        self.assertEqual(ReceivingItem.objects.count(), 0)
+        self.assertEqual(Stock.objects.count(), 0)
+        self.assertEqual(Transaction.objects.count(), 0)
 
     def test_import_view_requires_add_permission(self):
         user = User.objects.create_user(
@@ -1305,3 +1360,4 @@ class ReceivingDocumentAccessTest(TestCase):
                 for message in logs.output
             )
         )
+

--- a/backend/seed/README.md
+++ b/backend/seed/README.md
@@ -154,7 +154,7 @@ Expected columns for custom receiving import:
 - `sumber_dana_code` (required on the first row of each `document_number`; later rows may inherit or override it)
 - `location_code` (required on the first row of each `document_number`; later rows may inherit or override it)
 - `item_code` (required, maps to `Item.kode_barang`)
-- `quantity` (required)
+- `quantity` (required; must be a finite decimal greater than `0`)
 - `batch_lot` (optional; auto-generated if blank)
 - `expiry_date` (optional; defaults to `2099-12-31` when blank)
 - `unit_price` (optional; default `0`)
@@ -163,6 +163,7 @@ Import notes:
 
 - Baris pertama per `document_number` menjadi sumber data header `Receiving`.
 - `sumber_dana_code` dan `location_code` pada baris item akan override nilai header bila diisi.
+- Baris dengan `quantity` kosong, `0`, negatif, `NaN`, atau `Infinity` akan ditolak pada validasi import.
 
 Date formats accepted by parser:
 
@@ -176,3 +177,4 @@ Decimal parsing accepts comma separator.
 ### `stock.csv` (reference only)
 
 The repository still contains `stock.csv` template and stock admin import resources, but for first-time inventory bootstrap, `receiving.csv` is preferred because it posts auditable inbound transactions.
+


### PR DESCRIPTION
## Summary
- enforce receiving admin CSV import `quantity` as required and strictly positive
- keep `unit_price` behavior unchanged for this issue
- add regression coverage for blank, zero, and negative quantities plus no-side-effect rollback assertions

## Root Cause
The receiving CSV import path parsed blank `quantity` values as `0` through the shared decimal helper and accepted zero or negative quantities without a receiving-specific positivity check. That allowed invalid inbound rows to create `ReceivingItem`, `Stock`, and `Transaction(IN)` records.

## What Changed
- tightened `ReceivingAdmin._process_csv()` to validate `quantity` with `required=True` and `must_be_positive=True`
- extended the local receiving admin decimal wrapper to emit row-numbered validation errors for missing and non-positive quantities
- updated receiving CSV import tests so optional-default coverage still applies to `batch_lot`, `expiry_date`, and `unit_price`, while blank/zero/negative quantities now fail cleanly
- asserted that invalid quantity rows leave `Receiving`, `ReceivingItem`, `Stock`, and `Transaction` untouched

## Validation
- `python backend/manage.py test apps.receiving.tests.ReceivingCSVImportTest.test_process_csv_applies_defaults_for_empty_optional_fields apps.receiving.tests.ReceivingCSVImportTest.test_process_csv_rejects_blank_quantity apps.receiving.tests.ReceivingCSVImportTest.test_process_csv_rejects_zero_quantity apps.receiving.tests.ReceivingCSVImportTest.test_process_csv_rejects_negative_quantity apps.receiving.tests.ReceivingCSVImportTest.test_process_csv_invalid_decimal_has_clear_message apps.receiving.tests.ReceivingCSVImportTest.test_process_csv_rejects_nan_decimal`

## Notes
- the broader `ReceivingCSVImportTest` class still has two pre-existing admin-view failures unrelated to this quantity-validation fix: `test_import_view_requires_add_permission` currently returns `301` instead of `403`, and `test_import_view_logs_success` did not capture the expected `security` log entry during the earlier run.