### PR TITLE
[codex] fix receiving stock lost updates under concurrent inbound receipts (#154)

### DIFF
--- a/backend/apps/receiving/admin.py
+++ b/backend/apps/receiving/admin.py
@@ -24,6 +24,7 @@ from .models import (
     ReceivingDocument,
     ReceivingOrderItem,
     ReceivingTypeOption,
+    increment_receiving_stock,
 )
 from apps.items.models import Item, FundingSource, Location, Supplier
 from apps.core.upload_validation import validate_csv_upload, validate_receiving_document_upload
@@ -459,21 +460,16 @@ class ReceivingAdmin(admin.ModelAdmin):
                 counts["items"] += 1
 
                 # Stock — update or create
-                stock, created = Stock.objects.get_or_create(
+                increment_receiving_stock(
                     item=item,
                     location=row_location,
                     batch_lot=batch_lot,
                     sumber_dana=row_sumber_dana,
-                    defaults={
-                        "expiry_date": expiry_date,
-                        "quantity": quantity,
-                        "unit_price": unit_price,
-                        "receiving_ref": receiving,
-                    },
+                    expiry_date=expiry_date,
+                    quantity=quantity,
+                    unit_price=unit_price,
+                    receiving_ref=receiving,
                 )
-                if not created:
-                    stock.quantity += quantity
-                    stock.save()
                 counts["stock"] += 1
 
                 # Transaction

--- a/backend/apps/receiving/models.py
+++ b/backend/apps/receiving/models.py
@@ -1,8 +1,9 @@
 import unicodedata
 
-from django.db import models
+from django.db import IntegrityError, models, transaction
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.db.models import F
 from django.utils import timezone
 from apps.core.models import TimeStampedModel
 from .storage import ReceivingDocumentStorage
@@ -63,6 +64,84 @@ def validate_receiving_type_code(value):
         return receiving_type
 
     raise ValidationError({"receiving_type": "Masukkan pilihan yang valid."})
+
+
+def _create_receiving_stock_row(
+    *,
+    item,
+    location,
+    batch_lot,
+    sumber_dana,
+    expiry_date,
+    quantity,
+    unit_price,
+    receiving_ref,
+):
+    from apps.stock.models import Stock
+
+    return Stock.objects.create(
+        item=item,
+        location=location,
+        batch_lot=batch_lot,
+        sumber_dana=sumber_dana,
+        expiry_date=expiry_date,
+        quantity=quantity,
+        unit_price=unit_price,
+        receiving_ref=receiving_ref,
+    )
+
+
+def increment_receiving_stock(
+    *,
+    item,
+    location,
+    batch_lot,
+    sumber_dana,
+    expiry_date,
+    quantity,
+    unit_price,
+    receiving_ref,
+):
+    if not transaction.get_connection().in_atomic_block:
+        raise RuntimeError("increment_receiving_stock harus dipanggil dalam transaksi.")
+
+    from apps.stock.models import Stock
+
+    stock_filters = {
+        "item": item,
+        "location": location,
+        "batch_lot": batch_lot,
+        "sumber_dana": sumber_dana,
+    }
+    updated_at = timezone.now()
+
+    updated = Stock.objects.filter(**stock_filters).update(
+        quantity=F("quantity") + quantity,
+        updated_at=updated_at,
+    )
+    if updated:
+        return
+
+    try:
+        with transaction.atomic():
+            _create_receiving_stock_row(
+                item=item,
+                location=location,
+                batch_lot=batch_lot,
+                sumber_dana=sumber_dana,
+                expiry_date=expiry_date,
+                quantity=quantity,
+                unit_price=unit_price,
+                receiving_ref=receiving_ref,
+            )
+    except IntegrityError:
+        updated = Stock.objects.filter(**stock_filters).update(
+            quantity=F("quantity") + quantity,
+            updated_at=updated_at,
+        )
+        if updated:
+            return
+        raise
 
 
 class Receiving(TimeStampedModel):

--- a/backend/apps/receiving/tests.py
+++ b/backend/apps/receiving/tests.py
@@ -365,6 +365,7 @@ class ReceivingWorkflowCleanupTest(TestCase):
                 "items-0-unit_price": "1500",
                 "items-0-location": self.location.pk,
             },
+            secure=True,
         )
 
         self.assertEqual(response.status_code, 302)
@@ -1335,6 +1336,368 @@ class PlannedReceivingConcurrencyTest(TransactionTestCase):
         )
         stock = Stock.objects.get(batch_lot="BATCH-CONC")
         self.assertEqual(stock.quantity, Decimal("5"))
+
+
+class ReceivingStockConcurrencyTest(TransactionTestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="admin_receiving_stock_concurrency",
+            password="secret12345",
+        )
+        unit = Unit.objects.create(code="TABS", name="Tablet Stock")
+        category = Category.objects.create(code="OBATS", name="Obat Stock", sort_order=4)
+        self.item = Item.objects.create(
+            kode_barang="ITM-TEST-STOCK-0001",
+            nama_barang="Azithromycin 500mg",
+            satuan=unit,
+            kategori=category,
+            minimum_stock=Decimal("0"),
+        )
+        self.funding = FundingSource.objects.create(code="APBDS", name="APBD Stock")
+        self.location = Location.objects.create(code="LOC-S1", name="Gudang Stock Race")
+        self.batch_lot = "BATCH-STOCK-RACE"
+        self.expiry_date = "2030-01-01"
+
+    @staticmethod
+    def _csv_file(content):
+        return SimpleUploadedFile(
+            "receiving.csv",
+            content.encode("utf-8"),
+            content_type="text/csv",
+        )
+
+    def _regular_payload(self, document_number, quantity):
+        return {
+            "document_number": document_number,
+            "receiving_type": Receiving.ReceivingType.GRANT,
+            "receiving_date": "2026-03-16",
+            "supplier": "",
+            "sumber_dana": self.funding.pk,
+            "notes": "",
+            "items-TOTAL_FORMS": "1",
+            "items-INITIAL_FORMS": "0",
+            "items-MIN_NUM_FORMS": "0",
+            "items-MAX_NUM_FORMS": "1000",
+            "items-0-item": self.item.pk,
+            "items-0-quantity": str(quantity),
+            "items-0-batch_lot": self.batch_lot,
+            "items-0-expiry_date": self.expiry_date,
+            "items-0-unit_price": "1500",
+            "items-0-location": self.location.pk,
+        }
+
+    def _planned_payload(self, order_item, quantity):
+        return {
+            "items-TOTAL_FORMS": "1",
+            "items-INITIAL_FORMS": "0",
+            "items-MIN_NUM_FORMS": "0",
+            "items-MAX_NUM_FORMS": "1000",
+            "items-0-order_item": str(order_item.pk),
+            "items-0-quantity": str(quantity),
+            "items-0-batch_lot": self.batch_lot,
+            "items-0-expiry_date": self.expiry_date,
+            "items-0-unit_price": "1000",
+            "items-0-location": str(self.location.pk),
+        }
+
+    def _csv_content(self, document_number, quantity):
+        return (
+            "document_number,receiving_type,receiving_date,supplier_code,sumber_dana_code,"
+            "location_code,item_code,quantity,batch_lot,expiry_date,unit_price\n"
+            f"{document_number},GRANT,12/03/2026,,{self.funding.code},{self.location.code},"
+            f"{self.item.kode_barang},{quantity},{self.batch_lot},01/01/2030,1000\n"
+        )
+
+    def _post_regular_receiving(self, client, payload, results, key):
+        try:
+            response = client.post(
+                reverse("receiving:receiving_create"),
+                payload,
+                secure=True,
+            )
+            results[key] = {"status_code": response.status_code}
+        except Exception as exc:
+            results[key] = {"error": repr(exc)}
+        finally:
+            connections.close_all()
+
+    def _post_planned_receiving(self, client, receiving_pk, payload, results, key):
+        try:
+            response = client.post(
+                reverse("receiving:receiving_plan_receive", args=[receiving_pk]),
+                payload,
+                secure=True,
+            )
+            results[key] = {"status_code": response.status_code}
+        except Exception as exc:
+            results[key] = {"error": repr(exc)}
+        finally:
+            connections.close_all()
+
+    def _run_csv_import(self, csv_content, results, key):
+        admin = ReceivingAdmin(Receiving, AdminSite())
+        try:
+            counts = admin._process_csv(self._csv_file(csv_content), self.user)
+            results[key] = {"counts": counts}
+        except Exception as exc:
+            results[key] = {"error": repr(exc)}
+        finally:
+            connections.close_all()
+
+    def test_regular_receiving_concurrent_posts_accumulate_single_stock_row(self):
+        from apps.receiving import models as receiving_models
+
+        barrier = threading.Barrier(2)
+        original_create = receiving_models._create_receiving_stock_row
+
+        def synchronized_create(**kwargs):
+            barrier.wait(timeout=5)
+            return original_create(**kwargs)
+
+        client_one = Client()
+        client_two = Client()
+        client_one.force_login(self.user)
+        client_two.force_login(self.user)
+        results = {}
+
+        with patch(
+            "apps.receiving.models._create_receiving_stock_row",
+            side_effect=synchronized_create,
+        ):
+            thread_one = threading.Thread(
+                target=self._post_regular_receiving,
+                args=(
+                    client_one,
+                    self._regular_payload("RCV-2026-RACE-REG-1", Decimal("3")),
+                    results,
+                    "one",
+                ),
+            )
+            thread_two = threading.Thread(
+                target=self._post_regular_receiving,
+                args=(
+                    client_two,
+                    self._regular_payload("RCV-2026-RACE-REG-2", Decimal("4")),
+                    results,
+                    "two",
+                ),
+            )
+            thread_one.start()
+            thread_two.start()
+            thread_one.join(timeout=10)
+            thread_two.join(timeout=10)
+
+        self.assertFalse(thread_one.is_alive())
+        self.assertFalse(thread_two.is_alive())
+        self.assertNotIn("error", results.get("one", {}))
+        self.assertNotIn("error", results.get("two", {}))
+        self.assertEqual(
+            sorted(result["status_code"] for result in results.values()),
+            [302, 302],
+        )
+        stock = Stock.objects.get(
+            item=self.item,
+            location=self.location,
+            batch_lot=self.batch_lot,
+            sumber_dana=self.funding,
+        )
+        self.assertEqual(stock.quantity, Decimal("7"))
+        self.assertEqual(
+            Stock.objects.filter(
+                item=self.item,
+                location=self.location,
+                batch_lot=self.batch_lot,
+                sumber_dana=self.funding,
+            ).count(),
+            1,
+        )
+        self.assertEqual(Receiving.objects.count(), 2)
+        self.assertEqual(ReceivingItem.objects.count(), 2)
+        self.assertEqual(
+            Transaction.objects.filter(
+                reference_type=Transaction.ReferenceType.RECEIVING,
+            ).count(),
+            2,
+        )
+
+    def test_planned_receiving_concurrent_posts_accumulate_existing_stock(self):
+        from apps.receiving import models as receiving_models
+
+        Stock.objects.create(
+            item=self.item,
+            location=self.location,
+            batch_lot=self.batch_lot,
+            sumber_dana=self.funding,
+            expiry_date=date(2030, 1, 1),
+            quantity=Decimal("10"),
+            unit_price=Decimal("800"),
+        )
+        receiving_one = Receiving.objects.create(
+            document_number="RCV-2026-RACE-PLAN-1",
+            receiving_type=Receiving.ReceivingType.PROCUREMENT,
+            receiving_date=date(2026, 3, 16),
+            sumber_dana=self.funding,
+            status=Receiving.Status.APPROVED,
+            is_planned=True,
+            created_by=self.user,
+            approved_by=self.user,
+        )
+        receiving_two = Receiving.objects.create(
+            document_number="RCV-2026-RACE-PLAN-2",
+            receiving_type=Receiving.ReceivingType.PROCUREMENT,
+            receiving_date=date(2026, 3, 16),
+            sumber_dana=self.funding,
+            status=Receiving.Status.APPROVED,
+            is_planned=True,
+            created_by=self.user,
+            approved_by=self.user,
+        )
+        order_item_one = ReceivingOrderItem.objects.create(
+            receiving=receiving_one,
+            item=self.item,
+            planned_quantity=Decimal("3"),
+            received_quantity=Decimal("0"),
+            unit_price=Decimal("1000"),
+            is_cancelled=False,
+        )
+        order_item_two = ReceivingOrderItem.objects.create(
+            receiving=receiving_two,
+            item=self.item,
+            planned_quantity=Decimal("4"),
+            received_quantity=Decimal("0"),
+            unit_price=Decimal("1000"),
+            is_cancelled=False,
+        )
+
+        barrier = threading.Barrier(2)
+
+        def synchronized_increment(**kwargs):
+            barrier.wait(timeout=5)
+            return receiving_models.increment_receiving_stock(**kwargs)
+
+        client_one = Client()
+        client_two = Client()
+        client_one.force_login(self.user)
+        client_two.force_login(self.user)
+        results = {}
+
+        with patch(
+            "apps.receiving.views.increment_receiving_stock",
+            side_effect=synchronized_increment,
+        ):
+            thread_one = threading.Thread(
+                target=self._post_planned_receiving,
+                args=(
+                    client_one,
+                    receiving_one.pk,
+                    self._planned_payload(order_item_one, Decimal("3")),
+                    results,
+                    "one",
+                ),
+            )
+            thread_two = threading.Thread(
+                target=self._post_planned_receiving,
+                args=(
+                    client_two,
+                    receiving_two.pk,
+                    self._planned_payload(order_item_two, Decimal("4")),
+                    results,
+                    "two",
+                ),
+            )
+            thread_one.start()
+            thread_two.start()
+            thread_one.join(timeout=10)
+            thread_two.join(timeout=10)
+
+        self.assertFalse(thread_one.is_alive())
+        self.assertFalse(thread_two.is_alive())
+        self.assertNotIn("error", results.get("one", {}))
+        self.assertNotIn("error", results.get("two", {}))
+        self.assertEqual(
+            sorted(result["status_code"] for result in results.values()),
+            [302, 302],
+        )
+        stock = Stock.objects.get(
+            item=self.item,
+            location=self.location,
+            batch_lot=self.batch_lot,
+            sumber_dana=self.funding,
+        )
+        self.assertEqual(stock.quantity, Decimal("17"))
+        order_item_one.refresh_from_db()
+        order_item_two.refresh_from_db()
+        self.assertEqual(order_item_one.received_quantity, Decimal("3"))
+        self.assertEqual(order_item_two.received_quantity, Decimal("4"))
+        self.assertEqual(ReceivingItem.objects.filter(batch_lot=self.batch_lot).count(), 2)
+        self.assertEqual(
+            Transaction.objects.filter(
+                reference_type=Transaction.ReferenceType.RECEIVING,
+                batch_lot=self.batch_lot,
+            ).count(),
+            2,
+        )
+
+    def test_csv_import_concurrent_runs_accumulate_single_stock_row(self):
+        from apps.receiving import models as receiving_models
+
+        barrier = threading.Barrier(2)
+        original_create = receiving_models._create_receiving_stock_row
+
+        def synchronized_create(**kwargs):
+            barrier.wait(timeout=5)
+            return original_create(**kwargs)
+
+        results = {}
+
+        with patch(
+            "apps.receiving.models._create_receiving_stock_row",
+            side_effect=synchronized_create,
+        ):
+            thread_one = threading.Thread(
+                target=self._run_csv_import,
+                args=(
+                    self._csv_content("RCV-2026-RACE-CSV-1", Decimal("6")),
+                    results,
+                    "one",
+                ),
+            )
+            thread_two = threading.Thread(
+                target=self._run_csv_import,
+                args=(
+                    self._csv_content("RCV-2026-RACE-CSV-2", Decimal("8")),
+                    results,
+                    "two",
+                ),
+            )
+            thread_one.start()
+            thread_two.start()
+            thread_one.join(timeout=10)
+            thread_two.join(timeout=10)
+
+        self.assertFalse(thread_one.is_alive())
+        self.assertFalse(thread_two.is_alive())
+        self.assertNotIn("error", results.get("one", {}))
+        self.assertNotIn("error", results.get("two", {}))
+        self.assertEqual(results["one"]["counts"]["stock"], 1)
+        self.assertEqual(results["two"]["counts"]["stock"], 1)
+        stock = Stock.objects.get(
+            item=self.item,
+            location=self.location,
+            batch_lot=self.batch_lot,
+            sumber_dana=self.funding,
+        )
+        self.assertEqual(stock.quantity, Decimal("14"))
+        self.assertEqual(Receiving.objects.count(), 2)
+        self.assertEqual(ReceivingItem.objects.count(), 2)
+        self.assertEqual(
+            Transaction.objects.filter(
+                reference_type=Transaction.ReferenceType.RECEIVING,
+                batch_lot=self.batch_lot,
+            ).count(),
+            2,
+        )
+
 
 
 class ReceivingDocumentUploadValidationTest(TestCase):

--- a/backend/apps/receiving/views.py
+++ b/backend/apps/receiving/views.py
@@ -26,6 +26,7 @@ from .models import (
     ReceivingOrderItem,
     ReceivingTypeOption,
     get_reserved_receiving_type_codes,
+    increment_receiving_stock,
 )
 from .forms import (
     build_planned_receipt_item_formset,
@@ -101,21 +102,16 @@ def _create_verified_receiving(request, form, formset):
             item.received_at = timezone.now()
             item.save()
 
-            stock, created = Stock.objects.get_or_create(
+            increment_receiving_stock(
                 item=item.item,
                 location=item.location,
                 batch_lot=item.batch_lot,
                 sumber_dana=receiving.sumber_dana,
-                defaults={
-                    "expiry_date": item.expiry_date,
-                    "quantity": item.quantity,
-                    "unit_price": item.unit_price,
-                    "receiving_ref": receiving,
-                },
+                expiry_date=item.expiry_date,
+                quantity=item.quantity,
+                unit_price=item.unit_price,
+                receiving_ref=receiving,
             )
-            if not created:
-                stock.quantity += item.quantity
-                stock.save(update_fields=["quantity", "updated_at"])
 
             pending_transactions.append(
                 Transaction(
@@ -648,21 +644,16 @@ def receiving_plan_receive(request, pk):
                     )
                     order_item.save(update_fields=["received_quantity", "updated_at"])
 
-                    stock, created = Stock.objects.get_or_create(
+                    increment_receiving_stock(
                         item=item.item,
                         location=item.location,
                         batch_lot=item.batch_lot,
                         sumber_dana=receiving.sumber_dana,
-                        defaults={
-                            "expiry_date": item.expiry_date,
-                            "quantity": item.quantity,
-                            "unit_price": item.unit_price,
-                            "receiving_ref": receiving,
-                        },
+                        expiry_date=item.expiry_date,
+                        quantity=item.quantity,
+                        unit_price=item.unit_price,
+                        receiving_ref=receiving,
                     )
-                    if not created:
-                        stock.quantity += item.quantity
-                        stock.save(update_fields=["quantity", "updated_at"])
 
                     pending_transactions.append(
                         Transaction(


### PR DESCRIPTION
## Summary
- make inbound receiving stock increments concurrency-safe across regular receiving, planned receiving, and admin CSV import
- replace unlocked read-modify-write stock updates with a shared helper that uses database-side increments and duplicate-insert retry handling
- add concurrency regressions for all three inbound receiving mutation paths

## Root Cause
The receiving module updated `Stock.quantity` with an unlocked `get_or_create() -> quantity += incoming -> save()` pattern. When two inbound receipts hit the same `(item, location, batch_lot, sumber_dana)` tuple concurrently, both requests could read the same starting quantity and overwrite each other, leaving `Stock.quantity` lower than the sum of committed receipts even though both `Transaction(IN)` rows were appended.

## What Changed
- add `increment_receiving_stock()` in `backend/apps/receiving/models.py`
- update existing stock rows with `F("quantity") + qty` and explicit `updated_at`
- handle concurrent first-write insert races by retrying after `IntegrityError` inside a nested transaction savepoint
- route all inbound receiving stock mutations through the shared helper in:
  - regular receiving create
  - planned receiving receive
  - admin CSV import
- add `TransactionTestCase` concurrency coverage for:
  - concurrent regular receiving against a missing stock row
  - concurrent planned receiving against an existing stock row
  - concurrent admin CSV import against the same stock tuple

## Validation
Passed focused receiving tests:
- `python backend/manage.py test --keepdb apps.receiving.tests.ReceivingCSVImportTest.test_process_csv_applies_defaults_for_empty_optional_fields apps.receiving.tests.ReceivingWorkflowCleanupTest.test_regular_receiving_create_auto_verifies_and_posts_stock_transaction apps.receiving.tests.ReceivingWorkflowCleanupTest.test_plan_receive_allows_partial_and_full_receipt_mix apps.receiving.tests.ReceivingWorkflowCleanupTest.test_plan_receive_rejects_stale_locked_overage apps.receiving.tests.PlannedReceivingConcurrencyTest.test_plan_receive_concurrent_posts_do_not_over_receive apps.receiving.tests.ReceivingStockConcurrencyTest.test_regular_receiving_concurrent_posts_accumulate_single_stock_row apps.receiving.tests.ReceivingStockConcurrencyTest.test_planned_receiving_concurrent_posts_accumulate_existing_stock apps.receiving.tests.ReceivingStockConcurrencyTest.test_csv_import_concurrent_runs_accumulate_single_stock_row`

## Notes
- No schema, route, or workflow changes.
- No receiving metadata semantics changed on existing stock rows; the fix only protects quantity accumulation.

Closes #154