### PR TITLE
[codex] harden receiving quick-create lookup endpoints (#155)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ Before opening a PR, verify:
 - Receipt-confirmation throttling is mutation-only: create/edit/delete saves are POST-limited, while the create-form distribution preview uses non-mutating `GET` and must not consume that quota.
 - Throttled requests must continue through the centralized error pipeline and render as HTTP `429`.
 - `@user_mutation_ratelimit` covers all user mutation endpoints: create, update, toggle-active, and delete.
-- `@item_mutation_ratelimit` is reserved for item catalog and item-lookup POST mutations so item maintenance does not consume the user-management throttle bucket.
+- `@item_mutation_ratelimit` covers item catalog lookup POST mutations plus receiving quick-create lookup POST mutations so those writes do not consume the user-management throttle bucket.
 
 ## URL Routing Convention
 

--- a/SYSTEM_MODEL.md
+++ b/SYSTEM_MODEL.md
@@ -448,6 +448,7 @@ From `backend/config/settings.py`:
 - Sensitive POST throttling uses `django-ratelimit` with settings-backed defaults:
   - `USER_BULK_ACTION_RATE_LIMIT = 10/m`
   - `USER_MUTATION_RATE_LIMIT = 20/m`
+  - `ITEM_MUTATION_RATE_LIMIT = 20/m` (shared by item lookup quick-create POSTs and receiving lookup quick-create POSTs)
   - `USER_PASSWORD_RESET_RATE_LIMIT = 5/m`
   - `PASSWORD_CHANGE_RATE_LIMIT = 5/m`
   - `PUSKESMAS_RECEIPT_CONFIRMATION_MUTATION_RATE_LIMIT = 20/m` (legacy `PUSKESMAS_SBBK_MUTATION_RATE_LIMIT` remains accepted as fallback)

--- a/backend/apps/receiving/forms.py
+++ b/backend/apps/receiving/forms.py
@@ -1,3 +1,4 @@
+import unicodedata
 from decimal import Decimal, InvalidOperation
 
 from django import forms
@@ -6,12 +7,14 @@ from django.db.utils import OperationalError, ProgrammingError
 from django.forms import inlineformset_factory
 
 from apps.core.decimal_validation import validate_finite_decimal
+from apps.items.models import FundingSource, Supplier
 
 from .models import (
     Receiving,
     ReceivingItem,
     ReceivingOrderItem,
     ReceivingTypeOption,
+    get_reserved_receiving_type_codes,
     validate_receiving_type_code,
 )
 
@@ -42,6 +45,142 @@ def _get_receiving_type_widget_choices():
     return [("", "---------")] + _get_receiving_type_choices()
 
 
+def _normalize_text_value(value, *, field_label, max_length=None, allow_blank=True):
+    if value is None:
+        return "" if allow_blank else value
+
+    raw_value = str(value)
+    if "\x00" in raw_value:
+        raise forms.ValidationError(f"{field_label} mengandung karakter yang tidak valid.")
+
+    normalized = unicodedata.normalize("NFC", raw_value)
+    normalized = " ".join(normalized.strip().split())
+    if not normalized and not allow_blank:
+        raise forms.ValidationError(f"{field_label} wajib diisi.")
+    if max_length is not None and len(normalized) > max_length:
+        raise forms.ValidationError(
+            f"{field_label} tidak boleh lebih dari {max_length} karakter."
+        )
+    return normalized
+
+
+class ReceivingQuickCreateValidationMixin:
+    code_field_name = "code"
+    name_field_name = "name"
+
+    def _normalize_code(self, *, field_label="Kode", max_length=20):
+        code = _normalize_text_value(
+            self.cleaned_data.get(self.code_field_name),
+            field_label=field_label,
+            max_length=max_length,
+            allow_blank=False,
+        )
+        return code.upper()
+
+    def _normalize_name(self, *, field_label="Nama", max_length=100):
+        return _normalize_text_value(
+            self.cleaned_data.get(self.name_field_name),
+            field_label=field_label,
+            max_length=max_length,
+            allow_blank=False,
+        )
+
+    def _normalize_optional_text(self, field_name, *, field_label, max_length=None):
+        return _normalize_text_value(
+            self.cleaned_data.get(field_name),
+            field_label=field_label,
+            max_length=max_length,
+            allow_blank=True,
+        )
+
+    def _validate_unique_code(self, model_class, code):
+        queryset = model_class.objects.filter(code__iexact=code)
+        if self.instance and self.instance.pk:
+            queryset = queryset.exclude(pk=self.instance.pk)
+        if queryset.exists():
+            raise forms.ValidationError("Kode sudah digunakan. Gunakan kode lain.")
+        return code
+
+    def _validate_unique_name(self, model_class, value, *, field_name="name"):
+        queryset = model_class.objects.filter(**{f"{field_name}__iexact": value})
+        if self.instance and self.instance.pk:
+            queryset = queryset.exclude(pk=self.instance.pk)
+        if queryset.exists():
+            raise forms.ValidationError("Nama sudah digunakan. Gunakan nama lain.")
+        return value
+
+
+class ReceivingQuickCreateSupplierForm(ReceivingQuickCreateValidationMixin, forms.ModelForm):
+    class Meta:
+        model = Supplier
+        fields = ["code", "name", "address", "phone", "email", "notes"]
+
+    def clean_code(self):
+        code = self._normalize_code(max_length=20)
+        return self._validate_unique_code(Supplier, code)
+
+    def clean_name(self):
+        name = self._normalize_name(max_length=255)
+        return self._validate_unique_name(Supplier, name)
+
+    def clean_address(self):
+        return self._normalize_optional_text("address", field_label="Alamat")
+
+    def clean_phone(self):
+        return self._normalize_optional_text(
+            "phone",
+            field_label="Telepon",
+            max_length=50,
+        )
+
+    def clean_email(self):
+        email = self.cleaned_data.get("email")
+        if not email:
+            return ""
+        return _normalize_text_value(
+            email,
+            field_label="Email",
+            max_length=254,
+            allow_blank=True,
+        )
+
+    def clean_notes(self):
+        return self._normalize_optional_text("notes", field_label="Catatan")
+
+
+class ReceivingQuickCreateFundingSourceForm(ReceivingQuickCreateValidationMixin, forms.ModelForm):
+    class Meta:
+        model = FundingSource
+        fields = ["code", "name", "description"]
+
+    def clean_code(self):
+        code = self._normalize_code(max_length=20)
+        return self._validate_unique_code(FundingSource, code)
+
+    def clean_name(self):
+        name = self._normalize_name(max_length=100)
+        return self._validate_unique_name(FundingSource, name)
+
+    def clean_description(self):
+        return self._normalize_optional_text("description", field_label="Keterangan")
+
+
+class ReceivingQuickCreateReceivingTypeForm(ReceivingQuickCreateValidationMixin, forms.ModelForm):
+    class Meta:
+        model = ReceivingTypeOption
+        fields = ["code", "name"]
+
+    def clean_code(self):
+        code = self._normalize_code(max_length=20)
+        if code in get_reserved_receiving_type_codes():
+            raise forms.ValidationError(
+                f'Kode "{code}" sudah digunakan tipe bawaan sistem.'
+            )
+        return self._validate_unique_code(ReceivingTypeOption, code)
+
+    def clean_name(self):
+        name = self._normalize_name(max_length=100)
+        return self._validate_unique_name(ReceivingTypeOption, name)
 
 
 class BaseReceivingForm(forms.ModelForm):

--- a/backend/apps/receiving/tests.py
+++ b/backend/apps/receiving/tests.py
@@ -14,7 +14,7 @@ from django.test import Client, TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 
 from apps.distribution.models import Distribution, DistributionItem
-from apps.items.models import Category, Facility, FundingSource, Item, Location, Unit
+from apps.items.models import Category, Facility, FundingSource, Item, Location, Supplier, Unit
 from apps.receiving.admin import ReceivingAdmin, ReceivingCSVImportForm
 from apps.receiving.forms import (
     PlannedReceivingForm,
@@ -491,6 +491,101 @@ class ReceivingWorkflowCleanupTest(TestCase):
         receiving.refresh_from_db()
         self.assertNotEqual(receiving.status, Receiving.Status.CLOSED)
 
+    def test_quick_create_supplier_creates_normalized_lookup(self):
+        response = self.client.post(
+            reverse("receiving:quick_create_supplier"),
+            {
+                "code": " sup-01 ",
+                "name": "  PT   Farmasi Nusantara  ",
+                "address": "  Jl.  Merdeka   10  ",
+                "phone": " 08123  ",
+                "email": "vendor@example.com",
+                "notes": "  Mitra   utama  ",
+            },
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        supplier = Supplier.objects.get(code="SUP-01")
+        self.assertEqual(supplier.name, "PT Farmasi Nusantara")
+        self.assertEqual(supplier.address, "Jl. Merdeka 10")
+        self.assertEqual(supplier.phone, "08123")
+        self.assertEqual(supplier.notes, "Mitra utama")
+
+    def test_quick_create_supplier_rejects_invalid_email(self):
+        response = self.client.post(
+            reverse("receiving:quick_create_supplier"),
+            {"code": "SUP-01", "name": "PT Farmasi", "email": "tidak-valid"},
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Masukkan alamat email yang valid.", response.json()["error"])
+        self.assertEqual(Supplier.objects.count(), 0)
+
+    def test_quick_create_supplier_rejects_null_byte_input(self):
+        response = self.client.post(
+            reverse("receiving:quick_create_supplier"),
+            {"code": "SUP-01", "name": "PT Farma\x00si"},
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Karakter null tidak diizinkan.", response.json()["error"])
+        self.assertEqual(Supplier.objects.count(), 0)
+
+    def test_quick_create_supplier_rejects_duplicate_name_case_insensitive(self):
+        Supplier.objects.create(code="SUP-00", name="PT Farmasi Nusantara")
+
+        response = self.client.post(
+            reverse("receiving:quick_create_supplier"),
+            {"code": "SUP-01", "name": "  pt   farmasi   nusantara  "},
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Nama sudah digunakan", response.json()["error"])
+        self.assertEqual(Supplier.objects.count(), 1)
+
+    def test_quick_create_funding_source_creates_normalized_lookup(self):
+        response = self.client.post(
+            reverse("receiving:quick_create_funding_source"),
+            {
+                "code": " apbn ",
+                "name": "  Dana   Alokasi Khusus  ",
+                "description": "  Bantuan   pusat  ",
+            },
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        funding = FundingSource.objects.get(code="APBN")
+        self.assertEqual(funding.name, "Dana Alokasi Khusus")
+        self.assertEqual(funding.description, "Bantuan pusat")
+
+    def test_quick_create_funding_source_rejects_overlong_code(self):
+        response = self.client.post(
+            reverse("receiving:quick_create_funding_source"),
+            {"code": "X" * 21, "name": "Dana Baru"},
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("paling banyak 20 karakter", response.json()["error"])
+        self.assertEqual(FundingSource.objects.count(), 1)
+
+    def test_quick_create_funding_source_rejects_duplicate_name_case_insensitive(self):
+        FundingSource.objects.create(code="DAU", name="Dana Alokasi Umum")
+
+        response = self.client.post(
+            reverse("receiving:quick_create_funding_source"),
+            {"code": "DAU-2", "name": "  dana   alokasi umum  "},
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Nama sudah digunakan", response.json()["error"])
+
     def test_quick_create_receiving_type_adds_option_to_form_choices(self):
         response = self.client.post(
             reverse("receiving:quick_create_receiving_type"),
@@ -538,6 +633,7 @@ class ReceivingWorkflowCleanupTest(TestCase):
         response = self.client.post(
             reverse("receiving:quick_create_receiving_type"),
             {"code": "GRANT", "name": "Hibah Khusus"},
+            secure=True,
         )
         self.assertEqual(response.status_code, 400)
 
@@ -550,6 +646,34 @@ class ReceivingWorkflowCleanupTest(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertFalse(ReceivingTypeOption.objects.filter(code="RETURN_RS").exists())
+
+    def test_quick_create_receiving_type_rejects_duplicate_name_case_insensitive(self):
+        ReceivingTypeOption.objects.create(code="MUTASI", name="Mutasi Internal")
+
+        response = self.client.post(
+            reverse("receiving:quick_create_receiving_type"),
+            {"code": "MUT-2", "name": "  mutasi   internal  "},
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Nama sudah digunakan", response.json()["error"])
+
+    @override_settings(ITEM_MUTATION_RATE_LIMIT="1/m", RATELIMIT_USE_CACHE="locmem")
+    def test_receiving_quick_create_uses_shared_item_mutation_rate_limit(self):
+        first = self.client.post(
+            reverse("receiving:quick_create_supplier"),
+            {"code": "SUP-01", "name": "PT Farmasi"},
+            secure=True,
+        )
+        second = self.client.post(
+            reverse("receiving:quick_create_supplier"),
+            {"code": "SUP-02", "name": "PT Farmasi Dua"},
+            secure=True,
+        )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 429)
 
     def test_receiving_item_forms_use_name_only_item_labels(self):
         self.item.nama_barang = "Paracetamol 500mg [P]"

--- a/backend/apps/receiving/views.py
+++ b/backend/apps/receiving/views.py
@@ -15,8 +15,8 @@ from django.db.models.deletion import ProtectedError
 from django.utils import timezone
 
 from apps.core.decorators import module_scope_required, perm_required
+from apps.core.rate_limits import item_mutation_ratelimit
 from apps.core.upload_validation import sanitize_uploaded_filename
-from apps.items.models import Supplier, FundingSource
 from apps.stock.models import Stock, Transaction
 from apps.users.models import ModuleAccess
 from .models import (
@@ -24,22 +24,30 @@ from .models import (
     ReceivingDocument,
     ReceivingItem,
     ReceivingOrderItem,
-    ReceivingTypeOption,
-    get_reserved_receiving_type_codes,
     increment_receiving_stock,
 )
 from .forms import (
     build_planned_receipt_item_formset,
+    PlannedReceivingForm,
+    ReceivingCloseForm,
     ReceivingForm,
     ReceivingItemFormSet,
-    PlannedReceivingForm,
-    ReceivingOrderItemFormSet,
-    ReceivingReceiptItemFormSet,
-    ReceivingCloseForm,
     ReceivingOrderCloseItemFormSet,
+    ReceivingOrderItemFormSet,
+    ReceivingQuickCreateFundingSourceForm,
+    ReceivingQuickCreateReceivingTypeForm,
+    ReceivingQuickCreateSupplierForm,
+    ReceivingReceiptItemFormSet,
 )
 
 logger = logging.getLogger("security")
+
+
+def _json_form_errors(form):
+    errors = []
+    for field_errors in form.errors.values():
+        errors.extend(field_errors)
+    return " ".join(errors) or "Data tidak valid."
 
 
 def _safe_download_filename(document):
@@ -736,78 +744,42 @@ def receiving_plan_receive(request, pk):
 
 @login_required
 @perm_required("receiving.add_receiving")
+@item_mutation_ratelimit
 @require_POST
 def quick_create_supplier(request):
     """AJAX endpoint to create a new Supplier."""
-    code = request.POST.get("code", "").strip()
-    name = request.POST.get("name", "").strip()
+    form = ReceivingQuickCreateSupplierForm(request.POST)
+    if not form.is_valid():
+        return JsonResponse({"error": _json_form_errors(form)}, status=400)
 
-    if not code or not name:
-        return JsonResponse({"error": "Kode dan Nama wajib diisi."}, status=400)
-
-    if Supplier.objects.filter(code=code).exists():
-        return JsonResponse(
-            {"error": f'Supplier dengan kode "{code}" sudah ada.'}, status=400
-        )
-
-    supplier = Supplier.objects.create(
-        code=code,
-        name=name,
-        address=request.POST.get("address", "").strip(),
-        phone=request.POST.get("phone", "").strip(),
-        email=request.POST.get("email", "").strip(),
-        notes=request.POST.get("notes", "").strip(),
-    )
+    supplier = form.save()
     return JsonResponse({"id": supplier.pk, "text": str(supplier)})
 
 
 @login_required
 @perm_required("receiving.add_receiving")
+@item_mutation_ratelimit
 @require_POST
 def quick_create_funding_source(request):
     """AJAX endpoint to create a new FundingSource."""
-    code = request.POST.get("code", "").strip()
-    name = request.POST.get("name", "").strip()
+    form = ReceivingQuickCreateFundingSourceForm(request.POST)
+    if not form.is_valid():
+        return JsonResponse({"error": _json_form_errors(form)}, status=400)
 
-    if not code or not name:
-        return JsonResponse({"error": "Kode dan Nama wajib diisi."}, status=400)
-
-    if FundingSource.objects.filter(code=code).exists():
-        return JsonResponse(
-            {"error": f'Sumber dana dengan kode "{code}" sudah ada.'}, status=400
-        )
-
-    source = FundingSource.objects.create(
-        code=code,
-        name=name,
-        description=request.POST.get("description", "").strip(),
-    )
+    source = form.save()
     return JsonResponse({"id": source.pk, "text": str(source)})
 
 
 @login_required
 @perm_required("receiving.add_receiving")
+@item_mutation_ratelimit
 @require_POST
 def quick_create_receiving_type(request):
     """AJAX endpoint to create a new custom receiving type."""
-    code = request.POST.get("code", "").strip().upper()
-    name = request.POST.get("name", "").strip()
+    form = ReceivingQuickCreateReceivingTypeForm(request.POST)
+    if not form.is_valid():
+        return JsonResponse({"error": _json_form_errors(form)}, status=400)
 
-    if not code or not name:
-        return JsonResponse({"error": "Kode dan Nama wajib diisi."}, status=400)
-
-    reserved = get_reserved_receiving_type_codes()
-    if code in reserved:
-        return JsonResponse(
-            {"error": f'Kode "{code}" sudah digunakan tipe bawaan sistem.'},
-            status=400,
-        )
-
-    if ReceivingTypeOption.objects.filter(code=code).exists():
-        return JsonResponse(
-            {"error": f'Tipe penerimaan dengan kode "{code}" sudah ada.'}, status=400
-        )
-
-    option = ReceivingTypeOption.objects.create(code=code, name=name)
+    option = form.save()
     return JsonResponse({"id": option.code, "text": option.name})
 


### PR DESCRIPTION
## Summary
- replace raw POST writes in receiving quick-create supplier, funding source, and receiving type endpoints with form-based validation
- add shared @item_mutation_ratelimit protection to the three receiving quick-create endpoints
- add regression coverage for normalization, malformed input rejection, duplicate variants, and 429 behavior

## Root Cause
The receiving quick-create endpoints were reading raw equest.POST values and persisting lookup rows directly with objects.create(...). That bypassed the project’s form clean path, skipped normalization and duplicate-name guardrails, and left the endpoints unthrottled compared with the rest of the lookup creation surface.

## What Changed
- added receiving-local quick-create forms for supplier, funding source, and custom receiving type validation
- normalized and validated codes/names before save, including null-byte rejection and case-insensitive duplicate-name checks
- kept reserved built-in/internal receiving type code rejection in the quick-create path
- added shared item-mutation throttling to the receiving quick-create POST endpoints
- aligned AGENTS and system model docs with the shared throttle bucket

## Validation
`powershell
python backend/manage.py test --keepdb apps.receiving.tests.ReceivingWorkflowCleanupTest.test_quick_create_supplier_creates_normalized_lookup apps.receiving.tests.ReceivingWorkflowCleanupTest.test_quick_create_supplier_rejects_invalid_email apps.receiving.tests.ReceivingWorkflowCleanupTest.test_quick_create_supplier_rejects_null_byte_input apps.receiving.tests.ReceivingWorkflowCleanupTest.test_quick_create_supplier_rejects_duplicate_name_case_insensitive apps.receiving.tests.ReceivingWorkflowCleanupTest.test_quick_create_funding_source_creates_normalized_lookup apps.receiving.tests.ReceivingWorkflowCleanupTest.test_quick_create_funding_source_rejects_overlong_code apps.receiving.tests.ReceivingWorkflowCleanupTest.test_quick_create_funding_source_rejects_duplicate_name_case_insensitive apps.receiving.tests.ReceivingWorkflowCleanupTest.test_quick_create_receiving_type_adds_option_to_form_choices apps.receiving.tests.ReceivingWorkflowCleanupTest.test_quick_create_receiving_type_rejects_builtin_code apps.receiving.tests.ReceivingWorkflowCleanupTest.test_quick_create_receiving_type_rejects_reserved_internal_code apps.receiving.tests.ReceivingWorkflowCleanupTest.test_quick_create_receiving_type_rejects_duplicate_name_case_insensitive apps.receiving.tests.ReceivingWorkflowCleanupTest.test_receiving_quick_create_uses_shared_item_mutation_rate_limit
`

## Notes
- broader ReceivingWorkflowCleanupTest still includes unrelated preexisting 301 failures from non-secure test requests hitting SSL redirect behavior; those were not folded into this branch
- no schema, route, or workflow changes beyond quick-create validation/throttling hardening

Closes #155