### PR TITLE
fix(procurement): restore dynamic contract line rows

### DIFF
--- a/backend/apps/procurement/tests.py
+++ b/backend/apps/procurement/tests.py
@@ -369,6 +369,44 @@ class ProcurementWorkflowTests(TestCase):
             response,
             reverse("procurement:quick_create_funding_source"),
         )
+        self.assertContains(response, 'data-formset="procurement-lines"')
+        self.assertContains(response, 'class="btn btn-outline-primary btn-sm formset-add"', html=False)
+        self.assertContains(response, 'class="btn btn-outline-danger btn-sm formset-remove"', html=False)
+        self.assertContains(response, 'id="procurement-lines-empty"')
+
+    def test_contract_create_accepts_multiple_lines(self):
+        response = self.client.post(
+            reverse("procurement:contract_create"),
+            {
+                "document_number": "",
+                "contract_date": "2026-07-01",
+                "supplier": str(self.supplier.pk),
+                "sumber_dana": str(self.funding.pk),
+                "notes": "Kontrak dua baris",
+                "lines-TOTAL_FORMS": "2",
+                "lines-INITIAL_FORMS": "0",
+                "lines-MIN_NUM_FORMS": "0",
+                "lines-MAX_NUM_FORMS": "1000",
+                "lines-0-item": str(self.item.pk),
+                "lines-0-original_quantity": "10",
+                "lines-0-original_unit_price": "5000",
+                "lines-0-notes": "Baris pertama",
+                "lines-1-item": str(self.second_item.pk),
+                "lines-1-original_quantity": "20",
+                "lines-1-original_unit_price": "7000",
+                "lines-1-notes": "Baris kedua",
+            },
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        contract = ProcurementContract.objects.latest("pk")
+        lines = list(contract.lines.select_related("item").order_by("pk"))
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(lines[0].item, self.item)
+        self.assertEqual(lines[0].original_quantity, Decimal("10"))
+        self.assertEqual(lines[1].item, self.second_item)
+        self.assertEqual(lines[1].original_quantity, Decimal("20"))
 
     def test_procurement_quick_create_supplier_creates_lookup(self):
         response = self.client.post(

--- a/backend/templates/procurement/contract_form.html
+++ b/backend/templates/procurement/contract_form.html
@@ -48,7 +48,15 @@
                         <div class="alert alert-danger py-2">{{ formset.non_form_errors }}</div>
                         {% endif %}
                         {{ formset.management_form }}
-                        <div class="table-responsive">
+                        <div class="d-flex align-items-center justify-content-between mb-2">
+                            <span class="text-muted small">Tambah baris untuk menambah item kontrak.</span>
+                            <div class="d-flex gap-2">
+                                <button type="button" class="btn btn-outline-primary btn-sm formset-add" data-formset-target="procurement-lines">
+                                    <i class="bi bi-plus-lg me-1"></i>Tambah Baris
+                                </button>
+                            </div>
+                        </div>
+                        <div class="table-responsive" data-formset="procurement-lines" data-formset-prefix="{{ formset.prefix }}">
                             <table class="table align-middle">
                                 <thead>
                                     <tr>
@@ -56,12 +64,12 @@
                                         <th class="text-end">Jumlah Awal</th>
                                         <th class="text-end">Harga Awal</th>
                                         <th>Catatan</th>
-                                        <th>Hapus</th>
+                                        <th class="text-center">Hapus</th>
                                     </tr>
                                 </thead>
                                 <tbody>
                                     {% for line_form in formset %}
-                                    <tr>
+                                    <tr class="formset-row">
                                         <td>
                                             {{ line_form.id }}
                                             {{ line_form.item }}
@@ -70,13 +78,35 @@
                                         <td class="text-end">{{ line_form.original_quantity }}{{ line_form.original_quantity.errors }}</td>
                                         <td class="text-end">{{ line_form.original_unit_price }}{{ line_form.original_unit_price.errors }}</td>
                                         <td>{{ line_form.notes }}{{ line_form.notes.errors }}</td>
-                                        <td class="text-center">{% if line_form.instance.pk %}{{ line_form.DELETE }}{% endif %}</td>
+                                        <td class="text-center">
+                                            <button type="button" class="btn btn-outline-danger btn-sm formset-remove" title="Hapus Baris">
+                                                <i class="bi bi-trash"></i>
+                                            </button>
+                                            <div class="d-none">{{ line_form.DELETE }}</div>
+                                        </td>
                                     </tr>
                                     {% endfor %}
                                 </tbody>
                             </table>
                         </div>
                     </div>
+                    <template id="procurement-lines-empty">
+                        <tr class="formset-row">
+                            <td>
+                                {{ formset.empty_form.id }}
+                                {{ formset.empty_form.item }}
+                            </td>
+                            <td class="text-end">{{ formset.empty_form.original_quantity }}</td>
+                            <td class="text-end">{{ formset.empty_form.original_unit_price }}</td>
+                            <td>{{ formset.empty_form.notes }}</td>
+                            <td class="text-center">
+                                <button type="button" class="btn btn-outline-danger btn-sm formset-remove" title="Hapus Baris">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                                <div class="d-none">{{ formset.empty_form.DELETE }}</div>
+                            </td>
+                        </tr>
+                    </template>
 
                     <div class="d-flex gap-2 mt-4">
                         <button type="submit" class="btn btn-primary">Simpan</button>


### PR DESCRIPTION
## Summary
- restore add/remove row controls for procurement contract lines
- wire the contract form to the shared generic formset helper already used elsewhere in the app
- add regression coverage for the UI hooks and multi-line contract submission

## Testing
- python backend/manage.py test apps.procurement.tests --keepdb
- python backend/manage.py check