### PR TITLE
fix(procurement): restore amendment line delete controls

### DIFF
--- a/backend/apps/procurement/tests.py
+++ b/backend/apps/procurement/tests.py
@@ -408,6 +408,62 @@ class ProcurementWorkflowTests(TestCase):
         self.assertEqual(lines[1].item, self.second_item)
         self.assertEqual(lines[1].original_quantity, Decimal("20"))
 
+    def test_amendment_create_page_renders_formset_controls(self):
+        contract, line = self._approve_contract(quantity="10", unit_price="5000")
+
+        response = self.client.get(
+            reverse("procurement:amendment_create", args=[contract.pk]),
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'data-formset="procurement-amendment-lines"')
+        self.assertContains(response, 'class="btn btn-outline-primary btn-sm formset-add"', html=False)
+        self.assertContains(response, 'class="btn btn-outline-danger btn-sm formset-remove"', html=False)
+        self.assertContains(response, 'id="procurement-amendment-lines-empty"')
+        self.assertContains(response, str(line.pk))
+
+    def test_amendment_edit_allows_deleting_line(self):
+        contract, line = self._approve_contract(quantity="10", unit_price="5000")
+        amendment = ProcurementAmendment.objects.create(
+            contract=contract,
+            amendment_date=date(2026, 7, 8),
+            notes="Edit line",
+            status=ProcurementAmendment.Status.DRAFT,
+            created_by=self.admin,
+        )
+        amendment_line = ProcurementAmendmentLine.objects.create(
+            amendment=amendment,
+            contract_line=line,
+            revised_quantity=Decimal("12"),
+            revised_unit_price=Decimal("6000"),
+            notes="Hapus baris ini",
+        )
+
+        response = self.client.post(
+            reverse("procurement:amendment_edit", args=[amendment.pk]),
+            {
+                "document_number": amendment.document_number,
+                "amendment_date": "2026-07-08",
+                "notes": "Tanpa baris lama",
+                "lines-TOTAL_FORMS": "1",
+                "lines-INITIAL_FORMS": "1",
+                "lines-MIN_NUM_FORMS": "0",
+                "lines-MAX_NUM_FORMS": "1000",
+                "lines-0-id": str(amendment_line.pk),
+                "lines-0-contract_line": str(line.pk),
+                "lines-0-revised_quantity": "12",
+                "lines-0-revised_unit_price": "6000",
+                "lines-0-notes": "Hapus baris ini",
+                "lines-0-DELETE": "on",
+            },
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        amendment.refresh_from_db()
+        self.assertEqual(amendment.lines.count(), 0)
+
     def test_procurement_quick_create_supplier_creates_lookup(self):
         response = self.client.post(
             reverse("procurement:quick_create_supplier"),

--- a/backend/apps/procurement/tests.py
+++ b/backend/apps/procurement/tests.py
@@ -418,6 +418,7 @@ class ProcurementWorkflowTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'data-formset="procurement-amendment-lines"')
+        self.assertContains(response, 'data-formset-allow-empty="true"')
         self.assertContains(response, 'class="btn btn-outline-primary btn-sm formset-add"', html=False)
         self.assertContains(response, 'class="btn btn-outline-danger btn-sm formset-remove"', html=False)
         self.assertContains(response, 'id="procurement-amendment-lines-empty"')

--- a/backend/static/js/app.js
+++ b/backend/static/js/app.js
@@ -367,6 +367,7 @@ function initFormsetControls() {
 
         const tableBody = container.querySelector('tbody');
         if (!tableBody) return;
+        const allowEmpty = container.dataset.formsetAllowEmpty === 'true';
 
         const addButtons = document.querySelectorAll(`.formset-add[data-formset-target="${container.dataset.formset}"]`);
         addButtons.forEach((btn) => {
@@ -392,10 +393,10 @@ function initFormsetControls() {
             const visibleRows = Array.from(tableBody.querySelectorAll('tr.formset-row')).filter(
                 (r) => !r.classList.contains('d-none')
             );
-            if (visibleRows.length <= 1) {
+            const deleteInput = row.querySelector('input[type="checkbox"][name$="-DELETE"]');
+            if (visibleRows.length <= 1 && !allowEmpty) {
                 return;
             }
-            const deleteInput = row.querySelector('input[type="checkbox"][name$="-DELETE"]');
             if (deleteInput) {
                 deleteInput.checked = true;
                 row.classList.add('d-none');

--- a/backend/templates/procurement/amendment_form.html
+++ b/backend/templates/procurement/amendment_form.html
@@ -31,7 +31,7 @@
                                 </button>
                             </div>
                         </div>
-                        <div class="table-responsive" data-formset="procurement-amendment-lines" data-formset-prefix="{{ formset.prefix }}">
+                        <div class="table-responsive" data-formset="procurement-amendment-lines" data-formset-prefix="{{ formset.prefix }}" data-formset-allow-empty="true">
                             <table class="table align-middle">
                                 <thead>
                                     <tr>

--- a/backend/templates/procurement/amendment_form.html
+++ b/backend/templates/procurement/amendment_form.html
@@ -19,8 +19,19 @@
 
                     <div class="mt-4">
                         <h6 class="fw-semibold mb-3">Baris Amandemen</h6>
+                        {% if formset.non_form_errors %}
+                        <div class="alert alert-danger py-2">{{ formset.non_form_errors }}</div>
+                        {% endif %}
                         {{ formset.management_form }}
-                        <div class="table-responsive">
+                        <div class="d-flex align-items-center justify-content-between mb-2">
+                            <span class="text-muted small">Tambah atau hapus baris amandemen sesuai kebutuhan revisi kontrak.</span>
+                            <div class="d-flex gap-2">
+                                <button type="button" class="btn btn-outline-primary btn-sm formset-add" data-formset-target="procurement-amendment-lines">
+                                    <i class="bi bi-plus-lg me-1"></i>Tambah Baris
+                                </button>
+                            </div>
+                        </div>
+                        <div class="table-responsive" data-formset="procurement-amendment-lines" data-formset-prefix="{{ formset.prefix }}">
                             <table class="table align-middle">
                                 <thead>
                                     <tr>
@@ -28,12 +39,12 @@
                                         <th class="text-end">Qty Revisi</th>
                                         <th class="text-end">Harga Revisi</th>
                                         <th>Catatan</th>
-                                        <th>Hapus</th>
+                                        <th class="text-center">Hapus</th>
                                     </tr>
                                 </thead>
                                 <tbody>
                                     {% for line_form in formset %}
-                                    <tr>
+                                    <tr class="formset-row">
                                         <td>
                                             {{ line_form.id }}
                                             {{ line_form.contract_line }}
@@ -42,13 +53,35 @@
                                         <td class="text-end">{{ line_form.revised_quantity }}{{ line_form.revised_quantity.errors }}</td>
                                         <td class="text-end">{{ line_form.revised_unit_price }}{{ line_form.revised_unit_price.errors }}</td>
                                         <td>{{ line_form.notes }}{{ line_form.notes.errors }}</td>
-                                        <td class="text-center">{% if line_form.instance.pk %}{{ line_form.DELETE }}{% endif %}</td>
+                                        <td class="text-center">
+                                            <button type="button" class="btn btn-outline-danger btn-sm formset-remove" title="Hapus Baris">
+                                                <i class="bi bi-trash"></i>
+                                            </button>
+                                            <div class="d-none">{{ line_form.DELETE }}</div>
+                                        </td>
                                     </tr>
                                     {% endfor %}
                                 </tbody>
                             </table>
                         </div>
                     </div>
+                    <template id="procurement-amendment-lines-empty">
+                        <tr class="formset-row">
+                            <td>
+                                {{ formset.empty_form.id }}
+                                {{ formset.empty_form.contract_line }}
+                            </td>
+                            <td class="text-end">{{ formset.empty_form.revised_quantity }}</td>
+                            <td class="text-end">{{ formset.empty_form.revised_unit_price }}</td>
+                            <td>{{ formset.empty_form.notes }}</td>
+                            <td class="text-center">
+                                <button type="button" class="btn btn-outline-danger btn-sm formset-remove" title="Hapus Baris">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                                <div class="d-none">{{ formset.empty_form.DELETE }}</div>
+                            </td>
+                        </tr>
+                    </template>
 
                     <div class="d-flex gap-2 mt-4">
                         <button type="submit" class="btn btn-primary">Simpan</button>


### PR DESCRIPTION
## Summary
- restore visible delete controls for SPJ amendment lines
- wire amendment rows to the shared generic formset helper so add/remove works consistently
- add regression coverage for the rendered controls and deleting an existing amendment line

## Testing
- python backend/manage.py test apps.procurement.tests --keepdb
- python backend/manage.py check