### PR TITLE
fix: normalize allocation wizard batch availability and Step 3 ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Rincian skema kanonis tersedia di `SYSTEM_MODEL.md`.
 
 Instruksi setup environment, migrasi database, pengujian, versioning, dan proses import tersedia di `docs/developer_guide.md`.
 
-Repositori juga menyediakan helper Playwright lokal untuk verifikasi manual multi-role. Salin `.env.playwright.local.example` menjadi `.env.playwright.local`, isi akun `PUSKESMAS`, `GUDANG`, `KEPALA`, dan `ADMIN`, lalu jalankan `npm run playwright:bootstrap` diikuti `npm run playwright:open` dari root repositori.
+Repositori juga menyediakan helper Playwright lokal untuk verifikasi manual multi-role. Salin `.env.playwright.local.example` menjadi `.env.playwright.local`, isi akun `PUSKESMAS`, `GUDANG`, `KEPALA`, dan `ADMIN`, lalu jalankan `npm run playwright:bootstrap` diikuti `npm run playwright:open` dari root repositori. Untuk regresi browser yang sudah dikomitkan di folder `playwright/`, jalankan `npm run playwright:test`.
 
 ## Bantuan dan Kustomisasi
 
@@ -122,4 +122,5 @@ Untuk kebutuhan implementasi, konsultasi, atau penyesuaian sistem sesuai kebutuh
 ## Lisensi
 
 MIT. Lihat `LICENSE`.
+
 

--- a/backend/static/js/allocation-form.js
+++ b/backend/static/js/allocation-form.js
@@ -7,7 +7,7 @@
  * Step 4: Read-only review generated from form data
  */
 
-document.addEventListener('DOMContentLoaded', () => {
+function initAllocationForm() {
     const stockCatalog = JSON.parse(
         document.getElementById('allocation-stock-catalog')?.textContent || '[]'
     );
@@ -48,7 +48,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function getStepThreeReadiness() {
         const facilities = getSelectedFacilities();
-        const items = getFormsetItems();
+        const items = getBatchMatrixItems();
         return {
             facilities,
             items,
@@ -684,47 +684,63 @@ document.addEventListener('DOMContentLoaded', () => {
         return facilities;
     }
 
-    function getFormsetItems() {
-        const items = [];
-        const formsetContainer = document.querySelector('[data-formset="allocation-items"]');
-        if (!formsetContainer) return items;
+    function getDisplayGroupsForStep2() {
+        return getPrimaryAllocationRows()
+            .map((row) => {
+                const itemSelect = row.querySelector('.js-item-select');
+                const stockSelect = row.querySelector('.js-stock-select');
 
-        const rows = formsetContainer.querySelectorAll('.formset-row');
-        rows.forEach((row) => {
-            const deleteCheckbox = row.querySelector('[name$="-DELETE"]');
-            if (deleteCheckbox && deleteCheckbox.checked) return;
-            if (row.classList.contains('d-none') && !isGeneratedBatchRow(row)) return;
+                if (!itemSelect || !itemSelect.value || !stockSelect || !stockSelect.value) {
+                    return null;
+                }
 
-            const itemSelect = row.querySelector('.js-item-select');
-            const stockSelect = row.querySelector('.js-stock-select');
-            const qtyCell = row.querySelector('.js-available-qty');
-            const idField = row.querySelector('[name$="-id"]');
+                return {
+                    row,
+                    itemId: itemSelect.value,
+                    selectedStockIds: getSelectedStockIdsForGroup(row),
+                };
+            })
+            .filter(Boolean);
+    }
 
-            if (!itemSelect || !itemSelect.value) return;
-            if (!stockSelect || !stockSelect.value) return;
+    function buildBatchMatrixItem(row) {
+        const itemSelect = row.querySelector('.js-item-select');
+        const stockSelect = row.querySelector('.js-stock-select');
+        const idField = row.querySelector('[name$="-id"]');
 
-            const itemText = itemSelect.options[itemSelect.selectedIndex]?.text || '';
-            const stockText = stockSelect?.options[stockSelect.selectedIndex]?.text || '';
-            const available = parseFloat(qtyCell?.textContent) || 0;
+        if (!itemSelect || !itemSelect.value) return null;
+        if (!stockSelect || !stockSelect.value) return null;
 
-            // Try to determine a stable ID for the matrix row
-            const formIndex = idField?.value || itemSelect.name?.match(/items-(\d+)-/)?.[1] || '';
+        const itemText = itemSelect.options[itemSelect.selectedIndex]?.text || '';
+        const stockText = stockSelect.options[stockSelect.selectedIndex]?.text || '';
+        const stockMeta = getStockMeta(stockSelect.value);
+        const available = stockMeta?.availableQty || 0;
 
-            items.push({
-                formIndex: formIndex,
-                itemId: itemSelect.value,
-                itemName: itemText,
-                stockId: stockSelect?.value || '',
-                stockLabel: stockText,
-                available: available,
-            });
+        return {
+            formIndex: idField?.value || itemSelect.name?.match(/items-(\d+)-/)?.[1] || '',
+            itemId: itemSelect.value,
+            itemName: itemText,
+            stockId: stockSelect.value || '',
+            stockLabel: stockText,
+            available: available,
+            stockOrder: stockCatalog.findIndex((stock) => String(stock.id) === String(stockSelect.value)),
+        };
+    }
+
+    function getBatchMatrixItems() {
+        return getPrimaryAllocationRows().flatMap((row) => {
+            const groupRows = [row, ...getGeneratedRowsForGroup(row)]
+                .map((candidateRow) => buildBatchMatrixItem(candidateRow))
+                .filter(Boolean)
+                .sort((left, right) => left.stockOrder - right.stockOrder);
+
+            return groupRows;
         });
-        return items;
     }
 
     function buildMatrix() {
         const facilities = getSelectedFacilities();
-        const items = getFormsetItems();
+        const items = getBatchMatrixItems();
         const headerRow = document.getElementById('matrix-header-row');
         const matrixBody = document.getElementById('matrix-body');
         const emptyMsg = document.getElementById('matrix-empty-msg');
@@ -878,7 +894,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!container) return;
 
         const facilities = getSelectedFacilities();
-        const items = getFormsetItems();
+        const items = getBatchMatrixItems();
 
         if (items.length === 0 || facilities.length === 0) {
             container.innerHTML = '<div class="text-muted small">Tidak ada data untuk ditampilkan.</div>';
@@ -916,10 +932,31 @@ document.addEventListener('DOMContentLoaded', () => {
     // Utility
     // ────────────────────────────────────
 
+
+    window.__allocationWizardTestApi = {
+        getDisplayGroupsForStep2,
+        getBatchMatrixItems,
+        buildMatrix,
+        buildReviewMatrix,
+        buildReview,
+        goToStep,
+    };
     function escapeHtml(str) {
         if (!str) return '';
         const div = document.createElement('div');
         div.textContent = str;
         return div.innerHTML;
     }
-});
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAllocationForm, { once: true });
+} else {
+    initAllocationForm();
+}
+
+
+
+
+
+

--- a/backend/templates/allocation/allocation_form.html
+++ b/backend/templates/allocation/allocation_form.html
@@ -656,5 +656,6 @@
 {% if existing_allocations %}
 {{ existing_allocations|json_script:"existing-allocations" }}
 {% endif %}
-<script src="{% static 'js/allocation-form.js' %}?v={{ app_version }}-20260422b"></script>
+<script src="{% static 'js/allocation-form.js' %}?v={{ app_version }}-20260708a"></script>
 {% endblock %}
+

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -187,9 +187,10 @@ Perintah yang tersedia:
 - `npm run playwright:auth` untuk membuat atau memperbarui profil login tiap role tanpa membuka window manual.
 - `npm run playwright:refresh-auth` untuk menghapus profil lokal lalu login ulang dari nol.
 - `npm run playwright:open` untuk membuka empat window role sekaligus memakai profil persisten yang sudah tersimpan.
+- `npm run playwright:test` untuk menjalankan committed browser regression specs di folder `playwright/`.
 - `npm run playwright:bootstrap` untuk instal Chromium lalu menyiapkan sesi role awal.
 
-Profil browser disimpan secara lokal di `.playwright-profiles/` dan diabaikan oleh git. Bila password akun berubah atau sesi rusak, jalankan `npm run playwright:refresh-auth` lalu buka kembali window dengan `npm run playwright:open`.
+Profil browser disimpan secara lokal di `.playwright-profiles/` dan diabaikan oleh git. Bila password akun berubah atau sesi rusak, jalankan `npm run playwright:refresh-auth` lalu buka kembali window dengan `npm run playwright:open`. Committed specs dipakai hemat untuk regresi frontend yang sulit ditutup oleh test Django saja; helper multi-role tetap tersedia untuk verifikasi manual lintas role.
 
 ## Versioning
 
@@ -269,4 +270,5 @@ Gunakan siklus berikut agar dokumentasi tetap sinkron dengan kode:
 - `SYSTEM_MODEL.md`: referensi skema dan workflow utama
 - `CHANGELOG.md`: riwayat rilis
 - `security-audit/OWASP_TOP10_NON_PERSONAL_INFO_AUDIT_2026-02-27.md`: audit keamanan
+
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "playwright:auth": "node scripts/playwright/auth.mjs",
     "playwright:refresh-auth": "node scripts/playwright/auth.mjs --refresh",
     "playwright:open": "node scripts/playwright/open-windows.mjs",
+    "playwright:test": "npx playwright test",
     "playwright:bootstrap": "npm run playwright:install && npm run playwright:auth"
   },
   "devDependencies": {

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -1,4 +1,11 @@
-Local-only Playwright workspace for manual multi-role browser launching.
+Local Playwright workspace for browser-based verification and focused UI regressions.
 
-This directory is intentionally kept free of committed specs in the first version.
-Use the root npm scripts and files under scripts/playwright/ to bootstrap auth and open role windows.
+Use the root npm scripts and files under `scripts/playwright/` to bootstrap auth and open role windows for manual multi-role checking.
+
+Committed specs under `playwright/` are reserved for targeted browser regressions that are hard to cover with Django tests alone, such as frontend-derived wizard state.
+
+Useful commands from repo root:
+
+- `npm run playwright:bootstrap`
+- `npm run playwright:open`
+- `npm run playwright:test`

--- a/playwright/allocation-form.spec.ts
+++ b/playwright/allocation-form.spec.ts
@@ -1,0 +1,264 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "playwright/test";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const allocationScriptPath = path.resolve(__dirname, "../backend/static/js/allocation-form.js");
+
+const stockCatalog = [
+  {
+    id: 1001,
+    itemId: 501,
+    label: "0374MA032 | Tersedia: 160 | Exp: 07/01/2026",
+    availableQty: 160,
+  },
+  {
+    id: 1002,
+    itemId: 501,
+    label: "0374MA097 | Tersedia: 25 | Exp: 27/02/2027",
+    availableQty: 25,
+  },
+  {
+    id: 1003,
+    itemId: 501,
+    label: "UHEOE | Tersedia: 100 | Exp: 01/06/2030",
+    availableQty: 100,
+  },
+  {
+    id: 2001,
+    itemId: 601,
+    label: "401624 | Tersedia: 127 | Exp: 30/06/2027",
+    availableQty: 127,
+  },
+  {
+    id: 3001,
+    itemId: 701,
+    label: "21001025 | Tersedia: 255 | Exp: 28/07/2028",
+    availableQty: 255,
+  },
+];
+
+const existingAllocations = {
+  "101_1": 10,
+  "101_2": 10,
+  "102_1": 5,
+  "103_2": 7,
+  "201_1": 10,
+  "201_2": 10,
+  "301_1": 10,
+  "301_2": 10,
+};
+
+function buildItemOptions(selectedItemId: number) {
+  return [
+    { value: 501, label: "Vaksin BCG" },
+    { value: 601, label: "Vaksin HPV" },
+    { value: 701, label: "Vaksin polio ipv 0,5 ml (i.m.)" },
+  ]
+    .map((item) => `<option value="${item.value}" ${item.value === selectedItemId ? "selected" : ""}>${item.label}</option>`)
+    .join("");
+}
+
+function buildStockOptions(selectedStockId: number) {
+  return stockCatalog
+    .map((stock) => `<option value="${stock.id}" ${stock.id === selectedStockId ? "selected" : ""}>${stock.label}</option>`)
+    .join("");
+}
+
+function buildRowHtml({
+  index,
+  persistedId,
+  itemId,
+  stockId,
+  availableText,
+  summaryText,
+  groupId,
+  generated = false,
+}: {
+  index: number;
+  persistedId: number;
+  itemId: number;
+  stockId: number;
+  availableText: string;
+  summaryText: string;
+  groupId: string;
+  generated?: boolean;
+}) {
+  const hiddenClass = generated ? " d-none" : "";
+  const generatedAttrs = generated
+    ? ` data-generated-batch-row="true" data-batch-group-id="${groupId}"`
+    : ` data-batch-group-id="${groupId}"`;
+
+  return `
+    <tr class="formset-row${hiddenClass}"${generatedAttrs}>
+      <td>
+        <select class="js-item-select" name="items-${index}-item">
+          <option value="">---------</option>
+          ${buildItemOptions(itemId)}
+        </select>
+      </td>
+      <td>
+        <div class="allocation-item-stock-shell">
+          <div class="allocation-item-stock-source">
+            <select class="js-stock-select" name="items-${index}-stock">
+              <option value="">---------</option>
+              ${buildStockOptions(stockId)}
+            </select>
+          </div>
+          <div class="batch-checkbox-picker js-batch-picker" data-empty-label="Pilih batch stok">
+            <button type="button" class="batch-checkbox-trigger js-batch-picker-toggle">
+              <span class="batch-checkbox-trigger-text js-batch-picker-summary">${summaryText}</span>
+              <span class="batch-checkbox-trigger-icon">▾</span>
+            </button>
+            <div class="batch-checkbox-panel js-batch-picker-panel d-none">
+              <div class="batch-checkbox-list js-batch-checkbox-list"></div>
+              <div class="batch-checkbox-empty js-batch-checkbox-empty">Pilih barang terlebih dahulu.</div>
+            </div>
+          </div>
+        </div>
+      </td>
+      <td class="js-available-qty">${availableText}</td>
+      <td>
+        <button type="button" class="formset-remove">Hapus</button>
+        <input type="checkbox" name="items-${index}-DELETE">
+      </td>
+      <td class="d-none"><input type="hidden" name="items-${index}-total_qty_available" value="${availableText}"></td>
+      <td class="d-none"><input type="hidden" name="items-${index}-id" value="${persistedId}"></td>
+    </tr>
+  `;
+}
+
+function buildHarnessHtml(allocationScript: string) {
+  return `
+    <!DOCTYPE html>
+    <html lang="id">
+      <body>
+        <input id="id_title" value="Alokasi Uji Multi Batch">
+        <input id="id_allocation_date" value="2026-07-08">
+        <input id="id_referensi" value="REF-001">
+        <textarea id="id_notes">Catatan uji</textarea>
+
+        <div id="wizard-validation-alert" class="d-none"></div>
+
+        <button type="button" class="wizard-step-btn active" data-step="1"></button>
+        <button type="button" class="wizard-step-btn" data-step="2"></button>
+        <button type="button" class="wizard-step-btn" data-step="3"></button>
+        <button type="button" class="wizard-step-btn" data-step="4"></button>
+
+        <div class="wizard-panel" id="step-1"></div>
+        <div class="wizard-panel active" id="step-2">
+          <div data-formset="allocation-items" data-formset-prefix="items">
+            <input type="hidden" name="items-TOTAL_FORMS" value="5">
+            <table><tbody>
+              ${buildRowHtml({ index: 0, persistedId: 101, itemId: 501, stockId: 1001, availableText: "285", summaryText: "3 batch dipilih", groupId: "group-bcg" })}
+              ${buildRowHtml({ index: 1, persistedId: 201, itemId: 601, stockId: 2001, availableText: "127", summaryText: "401624 | Tersedia: 127 | Exp: 30/06/2027", groupId: "group-hpv" })}
+              ${buildRowHtml({ index: 2, persistedId: 301, itemId: 701, stockId: 3001, availableText: "255", summaryText: "21001025 | Tersedia: 255 | Exp: 28/07/2028", groupId: "group-polio" })}
+              ${buildRowHtml({ index: 3, persistedId: 102, itemId: 501, stockId: 1002, availableText: "25", summaryText: "3 batch dipilih", groupId: "group-bcg", generated: true })}
+              ${buildRowHtml({ index: 4, persistedId: 103, itemId: 501, stockId: 1003, availableText: "100", summaryText: "3 batch dipilih", groupId: "group-bcg", generated: true })}
+            </tbody></table>
+          </div>
+          <button type="button" class="js-wizard-next" data-next-step="3">Step 3</button>
+        </div>
+        <div class="wizard-panel" id="step-3">
+          <table>
+            <thead>
+              <tr id="matrix-header-row">
+                <th>Barang (Batch)</th>
+                <th>Stok Tersedia</th>
+                <th>Total</th>
+              </tr>
+            </thead>
+            <tbody id="matrix-body"></tbody>
+          </table>
+          <div id="matrix-empty-msg" class="d-none"></div>
+          <button type="button" class="js-wizard-next" data-next-step="4">Step 4</button>
+        </div>
+        <div class="wizard-panel" id="step-4">
+          <div id="review-header-content"></div>
+          <div id="review-matrix-content"></div>
+        </div>
+
+        <div class="selection-picker-list" id="allocation-facility-list">
+          <label class="selection-picker-item">
+            <span class="form-check-label">Puskesmas Arut Selatan</span>
+            <input type="checkbox" value="1" checked>
+          </label>
+          <label class="selection-picker-item">
+            <span class="form-check-label">Puskesmas Arut Utara</span>
+            <input type="checkbox" value="2" checked>
+          </label>
+          <div class="selection-picker-empty d-none"></div>
+        </div>
+
+        <div class="selection-picker-list" id="allocation-staff-list">
+          <label class="selection-picker-item">
+            <span class="form-check-label">Petugas Gudang</span>
+            <input type="checkbox" value="11" checked>
+          </label>
+          <div class="selection-picker-empty d-none"></div>
+        </div>
+
+        <template id="allocation-items-empty"></template>
+
+        <script id="allocation-stock-catalog" type="application/json">${JSON.stringify(stockCatalog)}</script>
+        <script id="allocation-facility-picker-meta" type="application/json">{}</script>
+        <script id="allocation-staff-picker-meta" type="application/json">{}</script>
+        <script id="existing-allocations" type="application/json">${JSON.stringify(existingAllocations)}</script>
+        <script>${allocationScript}</script>
+      </body>
+    </html>
+  `;
+}
+
+test.use({ headless: true });
+
+test("allocation wizard groups split batches with their source item in step 3 and step 4", async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+
+  const allocationScript = await fs.readFile(allocationScriptPath, "utf8");
+
+  await page.setContent(buildHarnessHtml(allocationScript));
+  await page.waitForTimeout(50);
+
+  expect(pageErrors).toEqual([]);
+  await expect(page.locator("#step-2 .js-available-qty").first()).toHaveText("285");
+
+  await page.evaluate(() => {
+    (window as typeof window & { __allocationWizardTestApi: { buildMatrix: () => void } }).__allocationWizardTestApi.buildMatrix();
+  });
+
+  const matrixRows = page.locator("#matrix-body tr");
+  await expect(matrixRows).toHaveCount(5);
+  await expect(page.locator("#matrix-body tr td:nth-child(2)")).toHaveText(["160", "25", "100", "127", "255"]);
+  await expect(page.locator("#matrix-body tr td:first-child > div")).toHaveText([
+    "Vaksin BCG",
+    "Vaksin BCG",
+    "Vaksin BCG",
+    "Vaksin HPV",
+    "Vaksin polio ipv 0,5 ml (i.m.)",
+  ]);
+  await expect(page.locator('input[name="alloc_101_1"]')).toHaveValue("10");
+  await expect(page.locator('input[name="alloc_101_2"]')).toHaveValue("10");
+  await expect(page.locator('input[name="alloc_102_1"]')).toHaveValue("5");
+  await expect(page.locator('input[name="alloc_103_2"]')).toHaveValue("7");
+
+  await page.evaluate(() => {
+    (window as typeof window & { __allocationWizardTestApi: { buildReviewMatrix: () => void } }).__allocationWizardTestApi.buildReviewMatrix();
+  });
+
+  const reviewRows = page.locator("#review-matrix-content tbody tr");
+  await expect(reviewRows).toHaveCount(5);
+  await expect(page.locator("#review-matrix-content tbody tr td:nth-child(2)")).toHaveText(["160", "25", "100", "127", "255"]);
+  await expect(page.locator("#review-matrix-content tbody tr td:first-child")).toContainText([
+    "Vaksin BCG",
+    "Vaksin BCG",
+    "Vaksin BCG",
+    "Vaksin HPV",
+    "Vaksin polio ipv 0,5 ml (i.m.)",
+  ]);
+});


### PR DESCRIPTION
## Summary
- fix the allocation edit wizard so Step 3 and Step 4 use per-batch availability instead of leaking the aggregated Step 2 value into the first selected batch row
- group split batches directly under their source item in Step 3/4 so multi-batch selections stay contiguous and easier to review
- add a committed Playwright regression for the frontend-derived wizard behavior and document the browser regression workflow

## Problem
When one item was split across multiple selected batches, the wizard mixed two representations at once:
- Step 2 showed one visible item row with aggregated availability
- Step 3/4 also rendered the generated per-batch rows

That caused the first Step 3 row to show a batch label such as `0374MA032 | Tersedia: 160` while the numeric availability column still showed the aggregated total `285`, and the remaining selected batches appeared again as separate rows below.

## Changes
- replace the Step 3/4 item source with a normalized per-batch list derived from the selected stock metadata
- keep the existing generated-row backend contract intact so POST field naming and persisted allocation item IDs do not change
- order Step 3/4 rows by primary Step 2 item group, then by stock catalog order inside that group
- make the allocation form script safe to initialize when loaded after DOM readiness
- bump the allocation form asset cache-buster to invalidate stale browser JS
- add `npm run playwright:test` and document the committed browser regression path

## Validation
- `npx playwright test playwright/allocation-form.spec.ts --project chromium-local --reporter=line`

## Risk
- limited to allocation wizard frontend behavior, Playwright regression coverage, and related docs/script wiring
- no schema, route, workflow, reservation, or backend POST contract changes