### PR TITLE
fix: hide Puskesmas dashboard navigation for facility-unlinked users

### DIFF
--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -368,12 +368,40 @@ class DashboardViewTests(TestCase):
         self.client.force_login(user)
         response = self.client.get(reverse("dashboard"))
 
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "dashboard_puskesmas.html")
-        self.assertIsNone(response.context["facility"])
-        self.assertEqual(list(response.context["recent_lplpos"]), [])
-        self.assertEqual(list(response.context["recent_requests"]), [])
+        self.assertEqual(response.status_code, 403)
+        self.assertContains(
+            response,
+            "Akun Anda belum terhubung ke fasilitas puskesmas.",
+            status_code=403,
+        )
 
+    def test_unlinked_puskesmas_user_sidebar_hides_facility_scoped_navigation(self):
+        user = User.objects.create_user(
+            username="sidebar-no-facility",
+            password="TestPassword123!",
+            role=User.Role.PUSKESMAS,
+        )
+
+        self.client.force_login(user)
+        response = self.client.get(reverse("password_change"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Konfirmasi Penerimaan")
+        self.assertNotContains(response, "Poli/Pustu Puskesmas")
+        self.assertNotContains(response, "Input Pemakaian")
+        self.assertNotContains(response, "Permintaan Barang")
+        self.assertNotContains(response, '<span>LPLPO</span>', html=False)
+
+    def test_linked_puskesmas_user_sidebar_keeps_facility_scoped_navigation(self):
+        self.client.force_login(self.puskesmas_user)
+        response = self.client.get(reverse("password_change"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Konfirmasi Penerimaan")
+        self.assertContains(response, "Poli/Pustu Puskesmas")
+        self.assertContains(response, "Input Pemakaian")
+        self.assertContains(response, "Permintaan Barang")
+        self.assertContains(response, '<span>LPLPO</span>', html=False)
     def test_global_dashboard_requires_stock_view_scope(self):
         user = User.objects.create_user(
             username="dashboard-blocked",
@@ -1729,3 +1757,4 @@ class SafeMediaUrlIntegrationTests(TestCase):
 
         self.assertIn('<i class="bi bi-hospital"></i>', rendered)
         self.assertNotIn("<img", rendered)
+

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -186,20 +186,7 @@ def dashboard(request):
     if request.user.role == User.Role.PUSKESMAS:
         facility = request.user.facility
         if not facility:
-            return render(
-                request,
-                "dashboard_puskesmas.html",
-                {
-                    "facility": None,
-                    "draft_lplpo_count": 0,
-                    "submitted_lplpo_count": 0,
-                    "reviewed_lplpo_count": 0,
-                    "recent_lplpos": [],
-                    "recent_requests": [],
-                    "latest_lplpo": None,
-                },
-            )
-
+            raise PermissionDenied("Akun Anda belum terhubung ke fasilitas puskesmas.")
         lplpo_queryset = LPLPO.objects.filter(facility=facility).select_related(
             "facility"
         )
@@ -526,3 +513,4 @@ class SystemSettingsUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateVi
                 )
             )
         return super().form_invalid(form)
+

--- a/backend/apps/users/context_processors.py
+++ b/backend/apps/users/context_processors.py
@@ -23,6 +23,12 @@ def access_flags(request):
             "is_super_admin_user": False,
         }
 
+    is_super_admin_user = is_super_admin(user)
+    has_linked_puskesmas_facility = is_super_admin_user or (
+        getattr(user, "role", None) != "PUSKESMAS"
+        or bool(getattr(user, "facility_id", None))
+    )
+
     return {
         "can_view_user_management": has_module_scope(
             user, ModuleAccess.Module.USERS, ModuleAccess.Scope.VIEW
@@ -62,9 +68,11 @@ def access_flags(request):
         ),
         "can_view_puskesmas": has_module_scope(
             user, ModuleAccess.Module.PUSKESMAS, ModuleAccess.Scope.VIEW
-        ),
+        )
+        and has_linked_puskesmas_facility,
         "can_view_lplpo": has_module_scope(
             user, ModuleAccess.Module.LPLPO, ModuleAccess.Scope.VIEW
-        ),
-        "is_super_admin_user": is_super_admin(user),
+        )
+        and has_linked_puskesmas_facility,
+        "is_super_admin_user": is_super_admin_user,
     }


### PR DESCRIPTION
## Summary
- deny dashboard access for facility-unlinked PUSKESMAS users with PermissionDenied
- hide facility-scoped Puskesmas and LPLPO sidebar entries for unlinked Puskesmas accounts
- add focused dashboard/sidebar regression tests for linked vs unlinked Puskesmas users

## Problem
Issue #168 identified an authorization/UI mismatch: a PUSKESMAS user without a linked facility could still load the dashboard and see Puskesmas operational navigation even though the underlying puskesmas and lplpo views correctly deny that access.

## Validation
- ./scripts/run-django-test.ps1 -Target apps.core.tests.test_core.DashboardViewTests

## Notes
- This PR is intentionally scoped to issue #168 only.
- No documentation updates were needed because the existing docs already state that non-superuser Puskesmas and LPLPO access requires a linked facility.