### PR TITLE
fix: point Puskesmas LPLPO sidebar link to my-list route

### DIFF
--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -374,6 +374,14 @@ class DashboardViewTests(TestCase):
         self.assertEqual(list(response.context["recent_lplpos"]), [])
         self.assertEqual(list(response.context["recent_requests"]), [])
 
+    def test_puskesmas_sidebar_lplpo_link_targets_my_list(self):
+        self.client.force_login(self.puskesmas_user)
+        response = self.client.get(reverse("password_change"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'href="/lplpo/my/"', html=False)
+        self.assertNotContains(response, 'href="/lplpo/"', html=False)
+
     def test_global_dashboard_requires_stock_view_scope(self):
         user = User.objects.create_user(
             username="dashboard-blocked",
@@ -1729,3 +1737,4 @@ class SafeMediaUrlIntegrationTests(TestCase):
 
         self.assertIn('<i class="bi bi-hospital"></i>', rendered)
         self.assertNotIn("<img", rendered)
+

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -241,7 +241,7 @@
                 </a>
                 {% endif %}
                 {% if can_view_lplpo and request.user.role == 'PUSKESMAS' %}
-                <a href="{% url 'lplpo:lplpo_list' %}"
+                <a href="{% url 'lplpo:lplpo_my_list' %}"
                     class="sidebar-link {% if request.resolver_match.app_name == 'lplpo' %}active{% endif %}"
                     data-label="LPLPO"
                     title="LPLPO">
@@ -576,3 +576,4 @@
 </body>
 
 </html>
+


### PR DESCRIPTION
## Summary
- change the Puskesmas sidebar LPLPO link to the scoped lplpo_my_list route
- keep the change limited to the Puskesmas navigation path
- add a focused regression test asserting the rendered sidebar href is /lplpo/my/

## Problem
Issue #169 identified that the Puskesmas sidebar linked LPLPO to the global queue route instead of the facility-scoped my-list route. That made the UI depend on redirect behavior rather than expressing the correct navigation target directly.

## Validation
- ./scripts/run-django-test.ps1 -Target apps.core.tests.test_core.DashboardViewTests

## Notes
- This PR is intentionally scoped to issue #169 only.
- No documentation updates were needed because this change aligns the UI with the already-established Puskesmas route convention.