### PR TITLE
fix: harden Admin Panel sidebar link against opener exposure

### DIFF
--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -409,6 +409,28 @@ class DashboardViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'href="/lplpo/my/"', html=False)
+
+    def test_admin_panel_sidebar_link_uses_noopener_noreferrer(self):
+        user = User.objects.create_user(
+            username="admin-panel-sidebar-user",
+            password="TestPassword123!",
+            role=User.Role.ADMIN_UMUM,
+        )
+        self._set_scope(
+            user,
+            ModuleAccess.Module.ADMIN_PANEL,
+            ModuleAccess.Scope.MANAGE,
+        )
+
+        self.client.force_login(user)
+        response = self.client.get(reverse("password_change"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'href="/admin/" class="sidebar-link" target="_blank" rel="noopener noreferrer" data-label="Admin Panel" title="Admin Panel"',
+            html=False,
+        )
     def test_global_dashboard_requires_stock_view_scope(self):
         user = User.objects.create_user(
             username="dashboard-blocked",

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -370,7 +370,7 @@
                     <i class="bi bi-send-check"></i><span>Riwayat Pengeluaran</span>
                 </a>
                 {% if can_open_admin_panel %}
-                <a href="{% url 'admin:index' %}" class="sidebar-link" target="_blank" data-label="Admin Panel" title="Admin Panel">
+                <a href="{% url 'admin:index' %}" class="sidebar-link" target="_blank" rel="noopener noreferrer" data-label="Admin Panel" title="Admin Panel">
                     <i class="bi bi-gear"></i><span>Admin Panel</span>
                 </a>
                 {% endif %}


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to the sidebar `Admin Panel` link that opens Django admin in a new tab
- add a regression test covering the hardened anchor for a user with `ADMIN_PANEL` manage scope

## Root Cause
The shared sidebar used `target="_blank"` for the admin link without explicit opener hardening, leaving an unnecessary browser security gap.

## Impact
This prevents the opened admin tab from retaining opener access to the originating application page and aligns the sidebar with expected browser hardening for new-tab links.

## Validation
- `./scripts/run-django-test.ps1 -Target apps.core.tests.test_core.DashboardViewTests`