### PR TITLE
fix(security): harden expired alerts redirect builder

### DIFF
--- a/backend/apps/expired/tests.py
+++ b/backend/apps/expired/tests.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from pathlib import Path
 
 from django.test import TestCase
 from django.urls import reverse
@@ -711,3 +712,15 @@ class ExpiredWorkflowTest(TestCase):
         response = self.client.get(reverse("expired:expired_alerts"))
 
         self.assertEqual(response.status_code, 403)
+
+
+class ExpiredAlertsFrontendSecurityTest(TestCase):
+    def test_alerts_script_uses_local_path_redirect_builder(self):
+        script_path = (
+            Path(__file__).resolve().parents[2] / 'static' / 'js' / 'expired-alerts.js'
+        )
+        script = script_path.read_text(encoding='utf-8')
+
+        self.assertIn('function buildSafeCreatePath', script)
+        self.assertIn('window.location.assign(nextPath);', script)
+        self.assertNotIn('new URL(createUrl, window.location.origin)', script)

--- a/backend/apps/expired/tests.py
+++ b/backend/apps/expired/tests.py
@@ -715,12 +715,31 @@ class ExpiredWorkflowTest(TestCase):
 
 
 class ExpiredAlertsFrontendSecurityTest(TestCase):
-    def test_alerts_script_uses_local_path_redirect_builder(self):
+    def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="expired_alerts_frontend",
+            password="secret12345",
+        )
+        self.client.force_login(self.user)
+
+    def test_alerts_script_submits_fixed_create_form(self):
         script_path = (
             Path(__file__).resolve().parents[2] / 'static' / 'js' / 'expired-alerts.js'
         )
         script = script_path.read_text(encoding='utf-8')
 
-        self.assertIn('function buildSafeCreatePath', script)
-        self.assertIn('window.location.assign(nextPath);', script)
+        self.assertIn("createForm.addEventListener('submit'", script)
+        self.assertIn('selectedStocksField.value = selected;', script)
+        self.assertNotIn('window.location.assign(', script)
         self.assertNotIn('new URL(createUrl, window.location.origin)', script)
+
+    def test_alerts_template_uses_fixed_create_form_action(self):
+        response = self.client.get(reverse("expired:expired_alerts"), secure=True)
+
+        self.assertContains(
+            response,
+            f'action="{reverse("expired:expired_create")}"',
+            html=False,
+        )
+        self.assertContains(response, 'id="createExpiredFromSelectedForm"', html=False)
+        self.assertContains(response, 'name="stocks"', html=False)

--- a/backend/static/js/expired-alerts.js
+++ b/backend/static/js/expired-alerts.js
@@ -28,15 +28,29 @@ document.addEventListener('DOMContentLoaded', function () {
 
     rowChecks().forEach(function (cb) { cb.addEventListener('change', syncButtonState); });
 
+    function buildSafeCreatePath(rawPath, selectedStocks) {
+        if (!rawPath || rawPath.charAt(0) !== '/') return null;
+        if (/^(?:[a-zA-Z][a-zA-Z0-9+.-]*:)?\/\//.test(rawPath)) return null;
+
+        var parts = rawPath.split('?');
+        var pathname = parts[0];
+        if (!pathname || pathname.charAt(0) !== '/') return null;
+
+        var params = new URLSearchParams(parts[1] || '');
+        params.set('stocks', selectedStocks);
+        var query = params.toString();
+        return query ? pathname + '?' + query : pathname;
+    }
+
     if (createBtn) {
         createBtn.addEventListener('click', function () {
             var selected = createBtn.dataset.selected || '';
             if (!selected) return;
             var createUrl = createBtn.getAttribute('data-create-url') || '';
-            if (!createUrl || createUrl.charAt(0) !== '/') return;
-            var url = new URL(createUrl, window.location.origin);
-            url.searchParams.set('stocks', selected);
-            window.location.assign(url.pathname + url.search);
+            var nextPath = buildSafeCreatePath(createUrl, selected);
+            if (!nextPath) return;
+
+            window.location.assign(nextPath);
         });
     }
 

--- a/backend/static/js/expired-alerts.js
+++ b/backend/static/js/expired-alerts.js
@@ -1,8 +1,5 @@
 /**
- * Expired alerts page: checkbox selection and create-from-selected logic
- *
- * Expected data attributes on #createExpiredFromSelected button:
- *   data-create-url – the URL for expired_create
+ * Expired alerts page: checkbox selection and fixed-form submission logic.
  */
 document.addEventListener('DOMContentLoaded', function () {
     var filterForm = document.querySelector('.filter-form');
@@ -10,7 +7,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var selectAll = document.getElementById('selectAllExpiredRows');
     var rowChecks = function () { return Array.from(document.querySelectorAll('.expired-stock-check')); };
+    var createForm = document.getElementById('createExpiredFromSelectedForm');
     var createBtn = document.getElementById('createExpiredFromSelected');
+    var selectedStocksField = document.getElementById('selectedExpiredStocks');
 
     function syncButtonState() {
         var selected = rowChecks().filter(function (cb) { return cb.checked; }).map(function (cb) { return cb.value; });
@@ -28,29 +27,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
     rowChecks().forEach(function (cb) { cb.addEventListener('change', syncButtonState); });
 
-    function buildSafeCreatePath(rawPath, selectedStocks) {
-        if (!rawPath || rawPath.charAt(0) !== '/') return null;
-        if (/^(?:[a-zA-Z][a-zA-Z0-9+.-]*:)?\/\//.test(rawPath)) return null;
-
-        var parts = rawPath.split('?');
-        var pathname = parts[0];
-        if (!pathname || pathname.charAt(0) !== '/') return null;
-
-        var params = new URLSearchParams(parts[1] || '');
-        params.set('stocks', selectedStocks);
-        var query = params.toString();
-        return query ? pathname + '?' + query : pathname;
-    }
-
-    if (createBtn) {
-        createBtn.addEventListener('click', function () {
+    if (createBtn && createForm && selectedStocksField) {
+        createForm.addEventListener('submit', function (event) {
             var selected = createBtn.dataset.selected || '';
-            if (!selected) return;
-            var createUrl = createBtn.getAttribute('data-create-url') || '';
-            var nextPath = buildSafeCreatePath(createUrl, selected);
-            if (!nextPath) return;
-
-            window.location.assign(nextPath);
+            if (!selected) {
+                event.preventDefault();
+                return;
+            }
+            selectedStocksField.value = selected;
         });
     }
 

--- a/backend/templates/expired/expired_alerts.html
+++ b/backend/templates/expired/expired_alerts.html
@@ -69,9 +69,12 @@
     <div class="table-header">
         <h5><i class="bi bi-exclamation-triangle me-2"></i>Pemantauan Stok Kedaluwarsa</h5>
         <div class="d-flex gap-2">
-            <button type="button" id="createExpiredFromSelected" class="btn btn-primary btn-sm" disabled data-create-url="{% url 'expired:expired_create' %}">
-                <i class="bi bi-plus-lg me-1"></i>Buat Dokumen dari Pilihan
-            </button>
+            <form method="get" action="{% url 'expired:expired_create' %}" id="createExpiredFromSelectedForm">
+                <input type="hidden" name="stocks" id="selectedExpiredStocks">
+                <button type="submit" id="createExpiredFromSelected" class="btn btn-primary btn-sm" disabled>
+                    <i class="bi bi-plus-lg me-1"></i>Buat Dokumen dari Pilihan
+                </button>
+            </form>
             <a href="{% url 'expired:expired_list' %}" class="btn btn-outline-secondary btn-sm">
                 <i class="bi bi-arrow-left me-1"></i>Daftar Dokumen
             </a>


### PR DESCRIPTION
## Summary
- replace the expired alerts create-from-selected redirect flow with a local-path builder that rejects remote or scheme-relative targets
- keep the selected stock query construction on the client without reparsing an arbitrary URL into a navigation target
- add a frontend security regression test for the expired alerts script

## Testing
- .\\scripts\\run-django-test.ps1 -Target apps.expired.tests -KeepDb

## Tracking
- Closes #178