### PR TITLE
fix: constrain item lookup redirect targets

### DIFF
--- a/backend/apps/items/tests.py
+++ b/backend/apps/items/tests.py
@@ -436,3 +436,59 @@ class TherapeuticClassQuickCreateTests(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertIn("Nama sudah digunakan", response.json()["error"])
+
+
+class ItemLookupRedirectSecurityTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="items_lookup_admin",
+            email="items_lookup_admin@example.com",
+            password="password12345",
+        )
+        self.client.force_login(self.user)
+
+    def test_unit_create_ignores_external_next_on_get(self):
+        response = self.client.get(
+            reverse("items:unit_create"),
+            {"next": "https://evil.example/phish"},
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'name="next"', html=False)
+        self.assertContains(
+            response,
+            f'href="{reverse("items:item_create")}"',
+            html=False,
+        )
+        self.assertNotContains(response, "https://evil.example/phish")
+
+    def test_unit_create_redirects_to_local_same_host_next_path(self):
+        response = self.client.post(
+            reverse("items:unit_create"),
+            {
+                "code": "TAB",
+                "name": "Tablet",
+                "description": "Satuan tablet",
+                "next": "https://testserver/items/create/?from=lookup",
+            },
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "/items/create/?from=lookup")
+
+    def test_unit_create_falls_back_when_next_uses_external_host(self):
+        response = self.client.post(
+            reverse("items:unit_create"),
+            {
+                "code": "CAP",
+                "name": "Capsule",
+                "description": "Satuan kapsul",
+                "next": "https://evil.example/items/create/",
+            },
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("items:item_create"))

--- a/backend/apps/items/tests.py
+++ b/backend/apps/items/tests.py
@@ -438,6 +438,7 @@ class TherapeuticClassQuickCreateTests(TestCase):
         self.assertIn("Nama sudah digunakan", response.json()["error"])
 
 
+@override_settings(ALLOWED_HOSTS=["testserver", "localhost", "127.0.0.1"])
 class ItemLookupRedirectSecurityTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_superuser(

--- a/backend/apps/items/tests.py
+++ b/backend/apps/items/tests.py
@@ -508,3 +508,19 @@ class ItemLookupRedirectSecurityTests(TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], reverse("items:item_create"))
+
+    def test_unit_create_ignores_same_host_backslash_path_on_get(self):
+        response = self.client.get(
+            reverse("items:unit_create"),
+            {"next": r"https://testserver/\evil.example/phish"},
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'name="next"', html=False)
+        self.assertContains(
+            response,
+            f'href="{reverse("items:item_create")}"',
+            html=False,
+        )
+        self.assertNotContains(response, r"/\evil.example/phish")

--- a/backend/apps/items/tests.py
+++ b/backend/apps/items/tests.py
@@ -493,3 +493,18 @@ class ItemLookupRedirectSecurityTests(TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], reverse("items:item_create"))
+
+    def test_unit_create_rejects_same_host_double_slash_path(self):
+        response = self.client.post(
+            reverse("items:unit_create"),
+            {
+                "code": "SYR",
+                "name": "Syrup",
+                "description": "Satuan sirup",
+                "next": "https://testserver//evil.example/phish",
+            },
+            secure=True,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("items:item_create"))

--- a/backend/apps/items/views.py
+++ b/backend/apps/items/views.py
@@ -48,6 +48,8 @@ def _get_safe_next_path(request):
     parsed_next = urlsplit(next_url)
     if not parsed_next.path.startswith("/"):
         return ""
+    if parsed_next.path.startswith("//"):
+        return ""
 
     return urlunsplit(("", "", parsed_next.path, parsed_next.query, ""))
 

--- a/backend/apps/items/views.py
+++ b/backend/apps/items/views.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlsplit, urlunsplit
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -32,14 +33,29 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 
-def _redirect_next_or_default(request, fallback_url_name):
+def _get_safe_next_path(request):
     next_url = request.POST.get("next") or request.GET.get("next")
-    if next_url and url_has_allowed_host_and_scheme(
+    if not next_url:
+        return ""
+
+    if not url_has_allowed_host_and_scheme(
         url=next_url,
         allowed_hosts={request.get_host()},
         require_https=request.is_secure(),
     ):
-        return redirect(next_url)
+        return ""
+
+    parsed_next = urlsplit(next_url)
+    if not parsed_next.path.startswith("/"):
+        return ""
+
+    return urlunsplit(("", "", parsed_next.path, parsed_next.query, ""))
+
+
+def _redirect_next_or_default(request, fallback_url_name):
+    next_path = _get_safe_next_path(request)
+    if next_path:
+        return redirect(next_path)
     return redirect(fallback_url_name)
 
 
@@ -234,6 +250,7 @@ def item_delete(request, pk):
 @perm_required("items.add_unit")
 @item_mutation_ratelimit
 def unit_create(request):
+    next_url = _get_safe_next_path(request)
     if request.method == "POST":
         form = UnitForm(request.POST)
         if form.is_valid():
@@ -249,7 +266,7 @@ def unit_create(request):
         {
             "form": form,
             "title": "Tambah Satuan",
-            "next_url": request.GET.get("next", ""),
+            "next_url": next_url,
         },
     )
 
@@ -258,6 +275,7 @@ def unit_create(request):
 @perm_required("items.add_category")
 @item_mutation_ratelimit
 def category_create(request):
+    next_url = _get_safe_next_path(request)
     if request.method == "POST":
         form = CategoryForm(request.POST)
         if form.is_valid():
@@ -273,7 +291,7 @@ def category_create(request):
         {
             "form": form,
             "title": "Tambah Kategori",
-            "next_url": request.GET.get("next", ""),
+            "next_url": next_url,
         },
     )
 
@@ -282,6 +300,7 @@ def category_create(request):
 @perm_required("items.add_program")
 @item_mutation_ratelimit
 def program_create(request):
+    next_url = _get_safe_next_path(request)
     if request.method == "POST":
         form = ProgramForm(request.POST)
         if form.is_valid():
@@ -297,7 +316,7 @@ def program_create(request):
         {
             "form": form,
             "title": "Tambah Program",
-            "next_url": request.GET.get("next", ""),
+            "next_url": next_url,
         },
     )
 
@@ -306,6 +325,7 @@ def program_create(request):
 @perm_required("items.add_therapeuticclass")
 @item_mutation_ratelimit
 def therapeutic_class_create(request):
+    next_url = _get_safe_next_path(request)
     if request.method == "POST":
         form = TherapeuticClassForm(request.POST)
         if form.is_valid():
@@ -321,7 +341,7 @@ def therapeutic_class_create(request):
         {
             "form": form,
             "title": "Tambah Terapi Obat",
-            "next_url": request.GET.get("next", ""),
+            "next_url": next_url,
         },
     )
 

--- a/backend/apps/items/views.py
+++ b/backend/apps/items/views.py
@@ -48,6 +48,8 @@ def _get_safe_next_path(request):
     parsed_next = urlsplit(next_url)
     if not parsed_next.path.startswith("/"):
         return ""
+    if "\\" in parsed_next.path:
+        return ""
     if parsed_next.path.startswith("//"):
         return ""
 


### PR DESCRIPTION
## Summary
- normalize item lookup `next` parameters into local path-only redirects before use
- reuse the sanitized path for both the post-success redirect and the lookup form cancel link
- add regression tests covering external-host rejection and same-host local redirect preservation

Closes #179.

## Testing
- `python manage.py test apps.items.tests.ItemLookupRedirectSecurityTests --noinput --keepdb --verbosity 2`
- `python manage.py test apps.items.tests --noinput --keepdb`