### PR TITLE
Harden receiving admin CSV import

### DIFF
--- a/SYSTEM_MODEL.md
+++ b/SYSTEM_MODEL.md
@@ -528,6 +528,7 @@ Defined in `backend/apps/receiving/admin.py` (`ReceivingAdmin.import_csv_view`):
 - Blank `expiry_date` values in the dedicated receiving import are accepted only for items with `requires_expiry_date=False`; older sentinel `2099-12-31` values are normalized by follow-up data migrations rather than being generated for new imports
 - The follow-up item backfill migration marks legacy catalog items with null-expiry stock/receiving history as `requires_expiry_date=False`, and stock admin import follows the same conditional blank-expiry rule
 - Historical copied sentinel dates in `DistributionItem.issued_expiry_date` and `PuskesmasReceiptConfirmationItem.expiry_date` are normalized to `NULL` by follow-up data migrations so downstream history and reports do not keep rendering `31/12/2099`
+- Parser-level validation normalizes CSV headers and text cells with stripped NFC text, rejects null bytes anywhere in the parsed CSV, enforces model-backed maximum lengths before saving, and rejects receiving/expiry dates whose years are outside `1000` through `9999`
 - Supported date formats in parser:
   - `DD/MM/YYYY`
   - `YYYY-MM-DD`

--- a/backend/apps/receiving/admin.py
+++ b/backend/apps/receiving/admin.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from csv import Error as CSVError
+import unicodedata
 
 from django.contrib import admin
 from django.shortcuts import render, redirect
@@ -15,7 +16,6 @@ import csv
 import io
 from collections import defaultdict
 from datetime import datetime
-from decimal import Decimal, InvalidOperation
 
 from apps.core.decimal_validation import parse_decimal_input
 from .models import (
@@ -34,6 +34,16 @@ from apps.stock.models import Stock, Transaction
 logger = logging.getLogger("security")
 CSV_IMPORT_MAX_SIZE_BYTES = 2 * 1024 * 1024
 RECEIVING_DOCUMENT_MAX_SIZE_BYTES = 10 * 1024 * 1024
+
+CSV_TEXT_LIMITS = {
+    "document_number": 100,
+    "receiving_type": 20,
+    "supplier_code": 20,
+    "sumber_dana_code": 20,
+    "location_code": 20,
+    "item_code": 50,
+    "batch_lot": 100,
+}
 
 
 # ── Inlines ────────────────────────────────────────────────
@@ -271,7 +281,10 @@ class ReceivingAdmin(admin.ModelAdmin):
         # Normalize headers (strip whitespace, lowercase)
         if not reader.fieldnames:
             raise ValueError("Header CSV tidak ditemukan.")
-        reader.fieldnames = [h.strip().lower() for h in reader.fieldnames]
+        reader.fieldnames = [
+            self._normalize_csv_text(h, row_num=1, field_name="header").lower()
+            for h in reader.fieldnames
+        ]
 
         required_columns = {
             "document_number",
@@ -291,12 +304,21 @@ class ReceivingAdmin(admin.ModelAdmin):
         grouped = defaultdict(list)
         for row_num, row in enumerate(reader, start=2):
             row = {
-                (k or "").strip(): (v or "").strip()
+                (k or "").strip(): self._normalize_csv_text(
+                    v,
+                    row_num=row_num,
+                    field_name=(k or "kolom"),
+                )
                 for k, v in row.items()
                 if k is not None
             }
             if not row.get("document_number"):
                 raise ValueError(f"Baris {row_num}: document_number kosong")
+            self._validate_text_length(
+                row["document_number"],
+                "document_number",
+                row_num,
+            )
             grouped[row["document_number"]].append((row_num, row))
 
         counts = {"receivings": 0, "items": 0, "stock": 0, "transactions": 0}
@@ -312,10 +334,20 @@ class ReceivingAdmin(admin.ModelAdmin):
             header_sumber_dana_code = first_row.get("sumber_dana_code", "")
             if not header_sumber_dana_code:
                 raise ValueError(f"Baris {first_row_num}: sumber_dana_code kosong")
+            self._validate_text_length(
+                header_sumber_dana_code,
+                "sumber_dana_code",
+                first_row_num,
+            )
 
             header_location_code = first_row.get("location_code", "")
             if not header_location_code:
                 raise ValueError(f"Baris {first_row_num}: location_code kosong")
+            self._validate_text_length(
+                header_location_code,
+                "location_code",
+                first_row_num,
+            )
 
             # Resolve FKs
             try:
@@ -333,8 +365,13 @@ class ReceivingAdmin(admin.ModelAdmin):
                 ) from exc
 
             supplier = None
-            supplier_code = first_row.get("supplier_code", "").strip()
+            supplier_code = first_row.get("supplier_code", "")
             if supplier_code:
+                self._validate_text_length(
+                    supplier_code,
+                    "supplier_code",
+                    first_row_num,
+                )
                 try:
                     supplier = Supplier.objects.get(code=supplier_code)
                 except Supplier.DoesNotExist as exc:
@@ -349,10 +386,17 @@ class ReceivingAdmin(admin.ModelAdmin):
                 field_name="receiving_date",
             )
 
+            receiving_type = first_row.get("receiving_type") or "GRANT"
+            self._validate_text_length(
+                receiving_type,
+                "receiving_type",
+                first_row_num,
+            )
+
             # Create Receiving (parent)
             receiving = Receiving(
                 document_number=doc_number,
-                receiving_type=first_row.get("receiving_type", "GRANT"),
+                receiving_type=receiving_type,
                 receiving_date=receiving_date,
                 supplier=supplier,
                 sumber_dana=sumber_dana,
@@ -378,6 +422,7 @@ class ReceivingAdmin(admin.ModelAdmin):
                 item_code = row.get("item_code", "")
                 if not item_code:
                     raise ValueError(f"Baris {row_num}: item_code kosong")
+                self._validate_text_length(item_code, "item_code", row_num)
                 try:
                     item = Item.objects.get(kode_barang=item_code)
                 except Item.DoesNotExist as exc:
@@ -403,6 +448,7 @@ class ReceivingAdmin(admin.ModelAdmin):
                 # Auto-generate batch_lot if empty
                 if not batch_lot:
                     batch_lot = f"SALDO-{row_num:04d}"
+                self._validate_text_length(batch_lot, "batch_lot", row_num)
 
                 # Blank expiry is allowed only for items that do not require it.
                 if expiry_date_str:
@@ -419,8 +465,8 @@ class ReceivingAdmin(admin.ModelAdmin):
                     expiry_date = None
 
                 # Row-level overrides (location/sumber_dana can vary per row)
-                row_sumber_dana_code = row.get("sumber_dana_code", "").strip()
-                row_location_code = row.get("location_code", "").strip()
+                row_sumber_dana_code = row.get("sumber_dana_code", "")
+                row_location_code = row.get("location_code", "")
                 effective_sumber_dana_code = (
                     row_sumber_dana_code or header_sumber_dana_code
                 )
@@ -430,6 +476,16 @@ class ReceivingAdmin(admin.ModelAdmin):
                     raise ValueError(f"Baris {row_num}: sumber_dana_code kosong")
                 if not effective_location_code:
                     raise ValueError(f"Baris {row_num}: location_code kosong")
+                self._validate_text_length(
+                    effective_sumber_dana_code,
+                    "sumber_dana_code",
+                    row_num,
+                )
+                self._validate_text_length(
+                    effective_location_code,
+                    "location_code",
+                    row_num,
+                )
 
                 try:
                     row_sumber_dana = FundingSource.objects.get(
@@ -493,6 +549,25 @@ class ReceivingAdmin(admin.ModelAdmin):
         return counts
 
     @staticmethod
+    def _normalize_csv_text(value, *, row_num, field_name):
+        normalized = unicodedata.normalize("NFC", str(value or "")).strip()
+        if "\x00" in normalized:
+            raise ValueError(
+                f"Baris {row_num}: {field_name} mengandung null byte yang tidak diizinkan"
+            )
+        return normalized
+
+    @staticmethod
+    def _validate_text_length(value, field_name, row_num):
+        max_length = CSV_TEXT_LIMITS.get(field_name)
+        if max_length is None:
+            return
+        if len(value) > max_length:
+            raise ValueError(
+                f"Baris {row_num}: {field_name} maksimal {max_length} karakter"
+            )
+
+    @staticmethod
     def _parse_date(value, row_num=None, field_name="tanggal"):
         """Parse date from DD/MM/YYYY or YYYY-MM-DD format."""
         value = (value or "").strip()
@@ -503,9 +578,15 @@ class ReceivingAdmin(admin.ModelAdmin):
 
         for fmt in ("%d/%m/%Y", "%Y-%m-%d", "%d-%m-%Y", "%d/%m/%y"):
             try:
-                return datetime.strptime(value, fmt).date()
+                parsed_date = datetime.strptime(value, fmt).date()
+                if parsed_date.year < 1000 or parsed_date.year > 9999:
+                    raise ValueError
+                return parsed_date
             except ValueError:
                 continue
+        year_message = ReceivingAdmin._date_year_error(value, row_num, field_name)
+        if year_message:
+            raise ValueError(year_message)
         if row_num is not None:
             raise ValueError(
                 f"Baris {row_num}: format {field_name} tidak dikenali: '{value}'. Gunakan DD/MM/YYYY."
@@ -513,6 +594,28 @@ class ReceivingAdmin(admin.ModelAdmin):
         raise ValueError(
             f"Format {field_name} tidak dikenali: '{value}'. Gunakan DD/MM/YYYY."
         )
+
+    @staticmethod
+    def _date_year_error(value, row_num, field_name):
+        parts = value.replace("-", "/").split("/")
+        year_text = ""
+        if len(parts) == 3:
+            if len(parts[0]) >= 4:
+                year_text = parts[0]
+            elif len(parts[2]) >= 4:
+                year_text = parts[2]
+
+        if not year_text or not year_text.isdigit():
+            return ""
+
+        year = int(year_text)
+        if 1000 <= year <= 9999:
+            return ""
+
+        message = f"{field_name} harus memiliki tahun antara 1000 dan 9999"
+        if row_num is not None:
+            return f"Baris {row_num}: {message}"
+        return message
 
     @staticmethod
     def _parse_decimal(

--- a/backend/apps/receiving/tests.py
+++ b/backend/apps/receiving/tests.py
@@ -304,6 +304,162 @@ class ReceivingCSVImportTest(TestCase):
         self.assertEqual(Stock.objects.count(), 0)
         self.assertEqual(Transaction.objects.count(), 0)
 
+    def test_process_csv_rejects_null_byte_in_later_row(self):
+        csv_content = (
+            "document_number,receiving_type,receiving_date,supplier_code,sumber_dana_code,"
+            "location_code,item_code,quantity,batch_lot,expiry_date,unit_price\n"
+            "RCV-2026-00001,GRANT,12/03/2026,,APBD,GUDANG,ITM-TEST-0001,10,B-001,01/01/2030,1000\n"
+            "RCV-2026-00001,GRANT,12/03/2026,,APBD,GUDANG,ITM-TEST-0001,10,BAD\x00BATCH,01/01/2030,1000\n"
+        )
+
+        with self.assertRaisesMessage(
+            ValueError,
+            "Baris 3: batch_lot mengandung null byte yang tidak diizinkan",
+        ):
+            self.admin._process_csv(self._csv_file(csv_content), self.user)
+
+        self.assertEqual(Receiving.objects.count(), 0)
+        self.assertEqual(ReceivingItem.objects.count(), 0)
+        self.assertEqual(Stock.objects.count(), 0)
+        self.assertEqual(Transaction.objects.count(), 0)
+
+    def test_process_csv_rejects_overlong_text_fields_before_save(self):
+        cases = [
+            (
+                "document_number",
+                "D" * 101,
+                "GRANT",
+                "APBD",
+                "GUDANG",
+                "ITM-TEST-0001",
+                "B-001",
+                "Baris 2: document_number maksimal 100 karakter",
+            ),
+            (
+                "receiving_type",
+                "RCV-2026-00001",
+                "R" * 21,
+                "APBD",
+                "GUDANG",
+                "ITM-TEST-0001",
+                "B-001",
+                "Baris 2: receiving_type maksimal 20 karakter",
+            ),
+            (
+                "sumber_dana_code",
+                "RCV-2026-00001",
+                "GRANT",
+                "S" * 21,
+                "GUDANG",
+                "ITM-TEST-0001",
+                "B-001",
+                "Baris 2: sumber_dana_code maksimal 20 karakter",
+            ),
+            (
+                "item_code",
+                "RCV-2026-00001",
+                "GRANT",
+                "APBD",
+                "GUDANG",
+                "I" * 51,
+                "B-001",
+                "Baris 2: item_code maksimal 50 karakter",
+            ),
+            (
+                "batch_lot",
+                "RCV-2026-00001",
+                "GRANT",
+                "APBD",
+                "GUDANG",
+                "ITM-TEST-0001",
+                "B" * 101,
+                "Baris 2: batch_lot maksimal 100 karakter",
+            ),
+        ]
+
+        for (
+            field_name,
+            doc,
+            receiving_type,
+            funding,
+            location,
+            item_code,
+            batch,
+            message,
+        ) in cases:
+            with self.subTest(field_name=field_name):
+                csv_content = (
+                    "document_number,receiving_type,receiving_date,supplier_code,sumber_dana_code,"
+                    "location_code,item_code,quantity,batch_lot,expiry_date,unit_price\n"
+                    f"{doc},{receiving_type},12/03/2026,,{funding},{location},{item_code},10,{batch},01/01/2030,1000\n"
+                )
+
+                with self.assertRaisesMessage(ValueError, message):
+                    self.admin._process_csv(self._csv_file(csv_content), self.user)
+
+                self.assertEqual(Receiving.objects.count(), 0)
+                self.assertEqual(ReceivingItem.objects.count(), 0)
+                self.assertEqual(Stock.objects.count(), 0)
+                self.assertEqual(Transaction.objects.count(), 0)
+
+    def test_process_csv_rejects_date_year_outside_supported_range(self):
+        cases = [
+            (
+                "receiving_date",
+                "01/01/0999",
+                "01/01/2030",
+                "Baris 2: receiving_date harus memiliki tahun antara 1000 dan 9999",
+            ),
+            (
+                "receiving_date",
+                "01/01/10000",
+                "01/01/2030",
+                "Baris 2: receiving_date harus memiliki tahun antara 1000 dan 9999",
+            ),
+            (
+                "expiry_date",
+                "12/03/2026",
+                "01/01/0999",
+                "Baris 2: expiry_date harus memiliki tahun antara 1000 dan 9999",
+            ),
+        ]
+
+        for field_name, receiving_date, expiry_date, message in cases:
+            with self.subTest(
+                field_name=field_name,
+                receiving_date=receiving_date,
+                expiry_date=expiry_date,
+            ):
+                csv_content = (
+                    "document_number,receiving_type,receiving_date,supplier_code,sumber_dana_code,"
+                    "location_code,item_code,quantity,batch_lot,expiry_date,unit_price\n"
+                    f"RCV-2026-00001,GRANT,{receiving_date},,APBD,GUDANG,ITM-TEST-0001,10,B-001,{expiry_date},1000\n"
+                )
+
+                with self.assertRaisesMessage(ValueError, message):
+                    self.admin._process_csv(self._csv_file(csv_content), self.user)
+
+                self.assertEqual(Receiving.objects.count(), 0)
+                self.assertEqual(ReceivingItem.objects.count(), 0)
+                self.assertEqual(Stock.objects.count(), 0)
+                self.assertEqual(Transaction.objects.count(), 0)
+
+    def test_process_csv_normalizes_and_strips_headers_and_values(self):
+        decomposed_doc_number = "RCV-2026-A\u0301"
+        csv_content = (
+            " document_number , receiving_type , receiving_date , supplier_code , sumber_dana_code ,"
+            " location_code , item_code , quantity , batch_lot , expiry_date , unit_price \n"
+            f" {decomposed_doc_number} , GRANT , 12/03/2026 , , APBD , GUDANG , ITM-TEST-0001 , 10 , B-001 , 01/01/2030 , 1000 \n"
+        )
+
+        result = self.admin._process_csv(self._csv_file(csv_content), self.user)
+
+        self.assertEqual(result["receivings"], 1)
+        receiving = Receiving.objects.get()
+        self.assertEqual(receiving.document_number, "RCV-2026-Á")
+        receiving_item = ReceivingItem.objects.get()
+        self.assertEqual(receiving_item.batch_lot, "B-001")
+
     def test_process_csv_rejects_nan_decimal(self):
         csv_content = (
             "document_number,receiving_type,receiving_date,supplier_code,sumber_dana_code,"
@@ -329,7 +485,7 @@ class ReceivingCSVImportTest(TestCase):
         )
         self.client.force_login(user)
 
-        response = self.client.get(reverse("admin:receiving_import_csv"))
+        response = self.client.get(reverse("admin:receiving_import_csv"), secure=True)
 
         self.assertEqual(response.status_code, 403)
 
@@ -345,6 +501,7 @@ class ReceivingCSVImportTest(TestCase):
             response = self.client.post(
                 reverse("admin:receiving_import_csv"),
                 {"csv_file": self._csv_file(csv_content)},
+                secure=True,
             )
 
         self.assertEqual(response.status_code, 302)
@@ -402,6 +559,20 @@ class ReceivingCSVImportTest(TestCase):
 
         with self.assertRaisesMessage(ValueError, "Baris 2: Masukkan pilihan yang valid."):
             self.admin._process_csv(self._csv_file(csv_content), self.user)
+
+    def test_import_view_template_documents_current_optional_columns(self):
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse("admin:receiving_import_csv"), secure=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<code>batch_lot</code>", html=False)
+        self.assertContains(response, "Opsional; otomatis dibuat jika kosong")
+        self.assertContains(response, "<code>expiry_date</code>", html=False)
+        self.assertContains(
+            response,
+            "Wajib hanya untuk item yang memerlukan tanggal kedaluwarsa",
+        )
 
 
 class ReceivingWorkflowCleanupTest(TestCase):

--- a/backend/seed/README.md
+++ b/backend/seed/README.md
@@ -168,6 +168,8 @@ Import notes:
 - Baris pertama per `document_number` menjadi sumber data header `Receiving`.
 - `sumber_dana_code` dan `location_code` pada baris item akan override nilai header bila diisi.
 - Baris dengan `quantity` kosong, `0`, negatif, `NaN`, atau `Infinity` akan ditolak pada validasi import.
+- Import menormalisasi spasi dan Unicode NFC pada header/sel teks, menolak null byte, serta menolak nilai teks yang melampaui panjang kolom model sebelum data disimpan.
+- `receiving_date` dan `expiry_date` harus memakai tahun antara `1000` dan `9999`.
 
 Date formats accepted by parser:
 

--- a/backend/templates/admin/receiving/csv_import.html
+++ b/backend/templates/admin/receiving/csv_import.html
@@ -4,76 +4,75 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block content %}
-<div style="max-width: 700px; margin: 20px auto;">
+<div id="content-main">
     <h2>{{ title }}</h2>
 
-    <div
-        style="background: #1a2733; padding: 15px; border-radius: 8px; margin-bottom: 20px; border: 1px solid #2a3a4a;">
-        <h4 style="margin-top: 0;">📋 Format CSV</h4>
-        <p style="font-size: 13px;">Setiap baris = 1 item penerimaan. Baris dengan <code>document_number</code> yang
+    <div class="module">
+        <h3>Format CSV</h3>
+        <p>Setiap baris = 1 item penerimaan. Baris dengan <code>document_number</code> yang
             sama akan dikelompokkan menjadi 1 dokumen penerimaan.</p>
-        <table style="width: 100%; font-size: 12px; border-collapse: collapse;">
+        <table>
             <thead>
-                <tr style="border-bottom: 1px solid #3a4a5a;">
-                    <th style="text-align: left; padding: 4px;">Kolom</th>
-                    <th style="text-align: left; padding: 4px;">Wajib</th>
-                    <th style="text-align: left; padding: 4px;">Keterangan</th>
+                <tr>
+                    <th scope="col">Kolom</th>
+                    <th scope="col">Wajib</th>
+                    <th scope="col">Keterangan</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
-                    <td style="padding: 3px;"><code>document_number</code></td>
-                    <td>✅</td>
+                    <td><code>document_number</code></td>
+                    <td>Ya</td>
                     <td>Nomor dokumen (contoh: SALDO-DAK-2026)</td>
                 </tr>
                 <tr>
-                    <td style="padding: 3px;"><code>receiving_type</code></td>
-                    <td>❌</td>
+                    <td><code>receiving_type</code></td>
+                    <td>Tidak</td>
                     <td>PROCUREMENT / GRANT (default: GRANT)</td>
                 </tr>
                 <tr>
-                    <td style="padding: 3px;"><code>receiving_date</code></td>
-                    <td>✅</td>
+                    <td><code>receiving_date</code></td>
+                    <td>Ya</td>
                     <td>Format: DD/MM/YYYY</td>
                 </tr>
                 <tr>
-                    <td style="padding: 3px;"><code>supplier_code</code></td>
-                    <td>❌</td>
+                    <td><code>supplier_code</code></td>
+                    <td>Tidak</td>
                     <td>Kode supplier (jika ada)</td>
                 </tr>
                 <tr>
-                    <td style="padding: 3px;"><code>sumber_dana_code</code></td>
-                    <td>✅</td>
+                    <td><code>sumber_dana_code</code></td>
+                    <td>Ya</td>
                     <td>Kode sumber dana</td>
                 </tr>
                 <tr>
-                    <td style="padding: 3px;"><code>location_code</code></td>
-                    <td>✅</td>
+                    <td><code>location_code</code></td>
+                    <td>Ya</td>
                     <td>Kode lokasi gudang</td>
                 </tr>
                 <tr>
-                    <td style="padding: 3px;"><code>item_code</code></td>
-                    <td>✅</td>
+                    <td><code>item_code</code></td>
+                    <td>Ya</td>
                     <td>Kode barang (kode_barang)</td>
                 </tr>
                 <tr>
-                    <td style="padding: 3px;"><code>quantity</code></td>
-                    <td>✅</td>
+                    <td><code>quantity</code></td>
+                    <td>Ya</td>
                     <td>Jumlah</td>
                 </tr>
                 <tr>
-                    <td style="padding: 3px;"><code>batch_lot</code></td>
-                    <td>✅</td>
-                    <td>Nomor batch/lot</td>
+                    <td><code>batch_lot</code></td>
+                    <td>Tidak</td>
+                    <td>Opsional; otomatis dibuat jika kosong</td>
                 </tr>
                 <tr>
-                    <td style="padding: 3px;"><code>expiry_date</code></td>
-                    <td>✅</td>
-                    <td>Format: DD/MM/YYYY</td>
+                    <td><code>expiry_date</code></td>
+                    <td>Kondisional</td>
+                    <td>Wajib hanya untuk item yang memerlukan tanggal kedaluwarsa. Format: DD/MM/YYYY</td>
                 </tr>
                 <tr>
-                    <td style="padding: 3px;"><code>unit_price</code></td>
-                    <td>❌</td>
+                    <td><code>unit_price</code></td>
+                    <td>Tidak</td>
                     <td>Harga satuan (default: 0)</td>
                 </tr>
             </tbody>
@@ -83,20 +82,20 @@
     <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
 
-        <div style="margin-bottom: 15px;">
-            <label for="id_csv_file" style="font-weight: bold; display: block; margin-bottom: 5px;">
+        <div class="form-row">
+            <label for="id_csv_file">
                 {{ form.csv_file.label }}
             </label>
             {{ form.csv_file }}
             {% if form.csv_file.errors %}
-            <p style="color: #e74c3c;">{{ form.csv_file.errors }}</p>
+            <div class="errors">{{ form.csv_file.errors }}</div>
             {% endif %}
         </div>
 
-        <button type="submit" class="default" style="padding: 8px 20px; cursor: pointer;">
-            🚀 Import
+        <button type="submit" class="default">
+            Import
         </button>
-        <a href=".." style="margin-left: 10px;">Batal</a>
+        <a href=".." class="button cancel-link">Batal</a>
     </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

Harden the custom Receiving admin CSV import at `/admin/receiving/receiving/import-csv/` so bad input is rejected at parser level before any receiving, stock, or transaction rows are written.

## Changes

- Normalize CSV headers and text cells with stripped NFC text.
- Reject null bytes anywhere in parsed CSV content with row-specific errors.
- Enforce model-backed max lengths for document numbers, receiving types, lookup codes, item codes, and batch lots before saving.
- Reject receiving and expiry dates whose years are outside `1000` through `9999`.
- Preserve existing import semantics: grouping by `document_number`, defaulting blank `receiving_type` to `GRANT`, ORM lookup validation, transaction-safe stock updates, and append-only `Transaction(IN)` creation.
- Refresh the admin import page so `batch_lot` and conditional `expiry_date` guidance matches runtime behavior.
- Update `SYSTEM_MODEL.md` and `backend/seed/README.md` with the stricter import contract.

## Validation

- `./scripts/run-django-test.ps1 -Target apps.receiving.tests.ReceivingCSVImportTest -KeepDb`
- `./scripts/run-django-test.ps1 -Target apps.core.tests.test_url_consistency -KeepDb`