### PR TITLE
Improve distribution queue ordering

### DIFF
--- a/backend/apps/distribution/tests.py
+++ b/backend/apps/distribution/tests.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -1645,6 +1645,57 @@ class DistributionWorkflowTest(SecureClientDefaultsMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, reverse("distribution:manual_lplpo_create"))
         self.assertNotContains(response, "Buat Distribusi LPLPO")
+
+    def test_distribution_list_orders_active_queue_by_created_date(self):
+        active_recent = Distribution.objects.create(
+            distribution_type=Distribution.DistributionType.LPLPO,
+            document_number="QUEUE-RECENT",
+            request_date=date(2026, 1, 1),
+            facility=self.facility,
+            status=Distribution.Status.DRAFT,
+            created_by=self.user,
+        )
+        active_older = Distribution.objects.create(
+            distribution_type=Distribution.DistributionType.ALLOCATION,
+            document_number="QUEUE-OLDER",
+            request_date=date(2026, 6, 1),
+            facility=self.facility,
+            status=Distribution.Status.VERIFIED,
+            created_by=self.user,
+        )
+        distributed_newer = Distribution.objects.create(
+            distribution_type=Distribution.DistributionType.SPECIAL_REQUEST,
+            document_number="QUEUE-DISTRIBUTED",
+            request_date=date(2026, 7, 1),
+            facility=self.facility,
+            status=Distribution.Status.DISTRIBUTED,
+            created_by=self.user,
+        )
+        Distribution.objects.filter(pk=active_recent.pk).update(
+            created_at=timezone.make_aware(datetime(2026, 7, 17, 9, 0))
+        )
+        Distribution.objects.filter(pk=active_older.pk).update(
+            created_at=timezone.make_aware(datetime(2026, 7, 16, 9, 0))
+        )
+        Distribution.objects.filter(pk=distributed_newer.pk).update(
+            created_at=timezone.make_aware(datetime(2026, 7, 18, 9, 0))
+        )
+
+        response = self.client.get(reverse("distribution:distribution_list"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Dibuat")
+        self.assertContains(response, "Tanggal Dokumen")
+        self.assertContains(response, "17/07/2026")
+        content = response.content.decode()
+        self.assertLess(
+            content.index("QUEUE-RECENT"),
+            content.index("QUEUE-OLDER"),
+        )
+        self.assertLess(
+            content.index("QUEUE-OLDER"),
+            content.index("QUEUE-DISTRIBUTED"),
+        )
 
     def test_edit_distribution_updates_assigned_staff(self):
         dist = self._create_distribution(

--- a/backend/apps/distribution/views.py
+++ b/backend/apps/distribution/views.py
@@ -6,7 +6,17 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 from django.db import transaction
-from django.db.models import DecimalField, ExpressionWrapper, F, Q, Sum, Value
+from django.db.models import (
+    Case,
+    DecimalField,
+    ExpressionWrapper,
+    F,
+    IntegerField,
+    Q,
+    Sum,
+    Value,
+    When,
+)
 from django.db.models.functions import Coalesce
 from django.shortcuts import get_object_or_404, redirect, render
 
@@ -50,6 +60,16 @@ _DISTRIBUTION_REPORT_TAB_URL_NAMES = {
     Distribution.DistributionType.ALLOCATION: "distribution:distribution_report_allocation",
     Distribution.DistributionType.LPLPO: "distribution:distribution_report_lplpo",
 }
+
+
+def _order_distribution_queue(queryset):
+    return queryset.annotate(
+        queue_status_order=Case(
+            When(status=Distribution.Status.DISTRIBUTED, then=Value(1)),
+            default=Value(0),
+            output_field=IntegerField(),
+        )
+    ).order_by("queue_status_order", "-created_at", "-request_date", "-pk")
 
 
 def _redirect_distribution_detail(pk):
@@ -262,10 +282,10 @@ def sync_distribution_staff_assignments(distribution, staff_users):
 @login_required
 @perm_required("distribution.view_distribution")
 def distribution_list(request):
-    queryset = (
-        Distribution.objects.select_related("facility", "created_by")
-        .exclude(distribution_type__in=["BORROW_RS", "SWAP_RS"])
-        .order_by("-request_date")
+    queryset = _order_distribution_queue(
+        Distribution.objects.select_related("facility", "created_by").exclude(
+            distribution_type__in=["BORROW_RS", "SWAP_RS"]
+        )
     )
     can_view_reports = _can_view_reports(request.user)
 
@@ -329,10 +349,10 @@ def distribution_report_lplpo(request):
 @login_required
 @perm_required("distribution.view_distribution")
 def special_request_list(request):
-    queryset = (
-        Distribution.objects.select_related("facility", "created_by")
-        .filter(distribution_type=Distribution.DistributionType.SPECIAL_REQUEST)
-        .order_by("-request_date")
+    queryset = _order_distribution_queue(
+        Distribution.objects.select_related("facility", "created_by").filter(
+            distribution_type=Distribution.DistributionType.SPECIAL_REQUEST
+        )
     )
 
     return _render_distribution_list(

--- a/backend/templates/distribution/distribution_list.html
+++ b/backend/templates/distribution/distribution_list.html
@@ -58,7 +58,8 @@
             <thead>
                 <tr>
                     <th>No. Dokumen</th>
-                    <th>Tanggal</th>
+                    <th>Dibuat</th>
+                    <th>Tanggal Dokumen</th>
                     <th>Tipe</th>
                     <th>Program</th>
                     <th>Faskes Tujuan</th>
@@ -71,6 +72,7 @@
                 {% for d in distributions %}
                 <tr>
                     <td><a href="{% url detail_url_name|default:'distribution:distribution_detail' d.pk %}" class="fw-semibold text-decoration-none">{{ d.document_number }}</a></td>
+                    <td>{{ d.created_at|date:"d/m/Y" }}</td>
                     <td>{{ d.request_date|date:"d/m/Y" }}</td>
                     <td>{{ d.get_distribution_type_display }}</td>
                     <td>{{ d.program|default:"-" }}</td>
@@ -87,7 +89,7 @@
                 </tr>
                 {% empty %}
                 <tr>
-                    <td colspan="8">
+                    <td colspan="9">
                         <div class="empty-state">
                             <i class="bi {% if module_icon %}{{ module_icon }}{% else %}bi-send{% endif %} d-block"></i>
                             <p>{{ empty_state_text|default:"Belum ada data distribusi" }}</p>


### PR DESCRIPTION
## Summary

- Show both `Dibuat` (`created_at`) and `Tanggal Dokumen` (`request_date`) on the distribution list.
- Order active distribution queue records ahead of completed rows, then by newest system-created date.
- Reuse the same operational ordering for the special-request list.

## Root Cause

The distribution history page sorted by `request_date` only. Generated work such as LPLPO, allocation, or special-request distributions could be created today but remain buried if the document/request date represented an older reporting period.

## Impact

Warehouse users now see newly created actionable distribution work without losing the official document date needed for reporting context.

## Validation

- `./scripts/run-django-test.ps1 -Target apps.distribution.tests.DistributionWorkflowTest.test_distribution_list_orders_active_queue_by_created_date`
- `./scripts/run-django-test.ps1 -Target apps.distribution.tests`
- `git diff --check`