### PR TITLE
fix: serve admin static files with whitenoise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ This project is a Django-based healthcare inventory system used by internal gove
 | Database | PostgreSQL 16 |
 | Cache/Broker | None (In-Memory / LocMemCache) |
 | UI | Django templates + Bootstrap 5 |
+| Static serving | WhiteNoise for collected static assets |
 | Auth model | `apps.users.User` |
 | Object audit | django-auditlog |
 | Settings | `backend/config/settings.py` |
@@ -155,6 +156,7 @@ Apply these principles:
 - Keep `DEBUG=False` production hardening documented and synchronized with settings.
 - Keep import workflow docs aligned with dry-run/confirm semantics from django-import-export.
 - Keep axes backend ordering and middleware placement documented exactly as configured.
+- Keep WhiteNoise middleware and `STORAGES["staticfiles"]` behavior documented so deployment notes reflect how collected admin/app static assets are served.
 - Keep sensitive POST throttling settings and the centralized `429` behavior documented exactly as configured.
 
 ## Development Commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on Keep a Changelog and follows Semantic Versioning (`MAJOR.
 
 ## [Unreleased]
 
+### Fixed
+
+- Admin/static assets: serve collected static files with WhiteNoise so deployed Django admin pages load their CSS and JavaScript correctly instead of rendering as unstyled fallback HTML.
+
 ## [1.29.0] - 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Solusi ini membantu proses inventaris berjalan lebih konsisten melalui alur doku
 | Database | PostgreSQL 16 |
 | Cache/Broker | None (In-Memory / LocMemCache) |
 | Antarmuka | Django Templates + Bootstrap 5 |
+| Static Files | WhiteNoise serving collected static assets |
 | Form | django-crispy-forms + crispy-bootstrap5 |
 | Import Data | django-import-export |
 | Keamanan & Audit | django-axes + django-ratelimit + django-auditlog |
@@ -95,6 +96,7 @@ Rincian skema kanonis tersedia di `SYSTEM_MODEL.md`.
 - Validasi kata sandi kuat dengan minimum 10 karakter dan validator kustom tambahan.
 - Kombinasi pengamanan sesi dan CSRF dengan `HttpOnly` serta `SameSite=Lax`.
 - Hardening produksi aktif saat `DEBUG=False`, termasuk secure cookie dan header keamanan terkait.
+- Static asset produksi dilayani melalui WhiteNoise dari hasil `collectstatic`, sehingga Django Admin `/admin/` dan UI aplikasi tetap memuat CSS/JavaScript ketika tidak ada web server eksternal yang melayani `/static/`.
 - Lampiran `ReceivingDocument` tidak lagi mengandalkan `MEDIA_URL`; file disimpan di `PRIVATE_MEDIA_ROOT` dan hanya diakses melalui endpoint unduh yang membutuhkan login + permission `receiving.view_receiving`.
 - Dukungan `CSRF_TRUSTED_ORIGINS`, backend email berbasis environment, dan batas field upload yang dinaikkan untuk form LPLPO berukuran besar.
 - Error umum `400/403/404/500` dirender lewat halaman khusus yang konsisten, mencatat event ke logger aplikasi, dan menyediakan tombol kembali ke halaman sebelumnya dengan fallback dinamis ke login atau dashboard.

--- a/SYSTEM_MODEL.md
+++ b/SYSTEM_MODEL.md
@@ -495,6 +495,7 @@ From `backend/config/settings.py`:
 - `DEBUG` defaults to `False` unless overridden by environment
 - `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS` are environment-driven comma-separated lists
 - `FEATURE_ALLOCATION_UI_ENABLED` is still loaded into settings for compatibility/tests, but current runtime routing and navigation rely on permissions/module scope instead of branching on this flag
+- Static assets are collected to `STATIC_ROOT = backend/staticfiles` and served by `whitenoise.middleware.WhiteNoiseMiddleware` using `STORAGES["staticfiles"] = "whitenoise.storage.CompressedStaticFilesStorage"`. The `default` storage alias remains Django `FileSystemStorage` for uploaded media, so this staticfiles setting does not replace media-file handling.
 - `AUTHENTICATION_BACKENDS` order:
   1. `axes.backends.AxesStandaloneBackend`
   2. `django.contrib.auth.backends.ModelBackend`

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -77,6 +77,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "apps.core.middleware.CSPMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -163,6 +164,14 @@ NUMBER_GROUPING = 3
 STATIC_URL = "/static/"
 STATICFILES_DIRS = [BASE_DIR / "static"]
 STATIC_ROOT = BASE_DIR / "staticfiles"
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedStaticFilesStorage",
+    },
+}
 
 # Media files (uploads)
 MEDIA_URL = "/media/"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,3 +22,4 @@ tablib==3.9.0
 tzdata==2025.3
 tzlocal==5.3.1
 wcwidth==0.6.0
+whitenoise==6.11.0

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -118,7 +118,21 @@ python manage.py migrate
 python manage.py createsuperuser
 ```
 
-### 6. Jalankan server pengembangan
+### 6. Kumpulkan static assets untuk deployment
+
+WhiteNoise melayani hasil `collectstatic` dari `STATIC_ROOT` (`backend/staticfiles`) untuk halaman admin dan aset aplikasi pada deployment. Jalankan perintah ini setelah dependency terpasang dan sebelum menjalankan build/image produksi:
+
+```bash
+python manage.py collectstatic --noinput
+```
+
+Untuk validasi tanpa menulis file, gunakan:
+
+```bash
+python manage.py collectstatic --noinput --dry-run
+```
+
+### 7. Jalankan server pengembangan
 
 ```bash
 python manage.py runserver

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ typing_extensions==4.15.0
 tzdata==2025.3
 tzlocal==5.3.1
 wcwidth==0.6.0
+whitenoise==6.11.0


### PR DESCRIPTION
## Summary

- Add WhiteNoise middleware so deployed Django can serve collected static files directly.
- Configure Django 6 `STORAGES` for compressed static assets while keeping the default file storage alias for uploaded media.
- Pin `whitenoise==6.11.0` in both requirements files.
- Add an Unreleased patch note for the admin static asset fix.

## Bug Fixed

This fixes the production issue where `/admin/` rendered as unstyled fallback HTML because Django admin CSS and JavaScript were not being served. With WhiteNoise enabled, collected static assets can be served by the app process, restoring the admin panel styling and behavior.

## Validation

- `python backend\manage.py check`
- `python backend\manage.py collectstatic --noinput --dry-run --verbosity 0`
- `git diff --check`