### PR TITLE
Improve login page responsive UX

### DIFF
--- a/backend/apps/core/forms.py
+++ b/backend/apps/core/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib.auth.forms import AuthenticationForm
 
 from crispy_forms.helper import FormHelper
+from crispy_forms.bootstrap import FieldWithButtons, StrictButton
 from crispy_forms.layout import Field, Layout
 
 from .models import SystemSettings
@@ -20,7 +21,7 @@ class CrispyAuthenticationForm(AuthenticationForm):
         self.fields["username"].label = "Nama Pengguna"
         self.fields["username"].widget.attrs.update(
             {
-                "autocomplete": "username",
+                "autocomplete": "off",
                 "autofocus": True,
                 "class": "form-control form-control-lg",
                 "placeholder": "Masukkan username",
@@ -43,7 +44,20 @@ class CrispyAuthenticationForm(AuthenticationForm):
         self.helper.disable_csrf = True
         self.helper.layout = Layout(
             Field("username", wrapper_class="auth-field-group"),
-            Field("password", wrapper_class="auth-field-group"),
+            FieldWithButtons(
+                Field("password"),
+                StrictButton(
+                    '<i class="bi bi-eye" aria-hidden="true"></i><span class="visually-hidden">Tampilkan kata sandi</span>',
+                    css_id="passwordToggle",
+                    css_class="btn-outline-secondary auth-password-toggle",
+                    type="button",
+                    aria_label="Tampilkan kata sandi",
+                    aria_pressed="false",
+                    data_password_toggle="id_password",
+                ),
+                input_size="input-group-lg",
+                css_class="auth-password-group flex-nowrap",
+            ),
         )
 
 

--- a/backend/apps/core/tests/test_core.py
+++ b/backend/apps/core/tests/test_core.py
@@ -928,11 +928,22 @@ class ErrorPageTemplateTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "registration/login.html")
-        self.assertContains(response, "<form", status_code=200)
+        self.assertContains(response, '<form method="post" action="/login/" class="auth-form" autocomplete="off">', status_code=200)
         self.assertIsInstance(response.context["form"], CrispyAuthenticationForm)
-        self.assertContains(response, 'autocomplete="username"', status_code=200)
+        self.assertContains(response, 'autocomplete="off"', status_code=200)
         self.assertContains(response, 'autocomplete="current-password"', status_code=200)
         self.assertContains(response, 'name="next"', status_code=200)
+        self.assertNotContains(response, "auth-showcase")
+        self.assertContains(response, 'class="auth-layout auth-layout-centered"', status_code=200)
+        self.assertContains(response, 'class="auth-panel px-3 px-md-0"', status_code=200)
+        self.assertContains(response, 'class="auth-card-brand"', status_code=200)
+        self.assertContains(response, 'class="auth-eyebrow auth-eyebrow-card"', status_code=200)
+        self.assertContains(response, 'id="passwordToggle"', status_code=200)
+        self.assertContains(response, 'type="button"', status_code=200)
+        self.assertContains(response, 'aria-pressed="false"', status_code=200)
+        self.assertContains(response, 'data-password-toggle="id_password"', status_code=200)
+        self.assertContains(response, 'js/login.js', status_code=200)
+        self.assertNotContains(response, 'value="super_admin"')
 
     def test_failed_login_renders_bound_form_errors_without_user_enumeration(self):
         user = User.objects.create_user(
@@ -952,7 +963,14 @@ class ErrorPageTemplateTests(TestCase):
         self.assertEqual(known_response.status_code, 200)
         self.assertEqual(unknown_response.status_code, 200)
         self.assertTemplateUsed(known_response, "registration/login.html")
+        self.assertContains(
+            known_response,
+            '<div class="alert alert-danger auth-alert" role="alert">',
+            status_code=200,
+            html=False,
+        )
         self.assertContains(known_response, "Autentikasi gagal.", status_code=200)
+        self.assertContains(known_response, "<ul", status_code=200)
         self.assertTrue(known_response.context["form"].non_field_errors())
         self.assertEqual(
             list(known_response.context["form"].non_field_errors()),
@@ -1077,6 +1095,12 @@ class LoginLockoutTests(TestCase):
 
         self.assertEqual(response.status_code, 429)
         self.assertTemplateUsed(response, "registration/lockout.html")
+        self.assertContains(
+            response,
+            '<div class="alert alert-warning auth-alert auth-alert-lockout" role="alert">',
+            status_code=429,
+            html=False,
+        )
 
     def test_shared_source_ip_does_not_lock_unrelated_usernames(self):
         for index in range(3):

--- a/backend/static/css/style.css
+++ b/backend/static/css/style.css
@@ -909,6 +909,7 @@ body {
     border: 1px solid rgba(255, 255, 255, 0.12);
     box-shadow: 0 28px 60px rgba(15, 23, 42, 0.24);
     backdrop-filter: blur(16px);
+    align-items: center;
 }
 
 .auth-showcase::before {
@@ -953,6 +954,33 @@ body {
     color: #fff;
 }
 
+.auth-card-brand {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 22px;
+}
+
+.auth-brand-mark-card {
+    width: 56px;
+    height: 56px;
+    border-radius: 16px;
+    flex: 0 0 auto;
+    background: rgba(79, 140, 255, 0.12);
+    border-color: rgba(79, 140, 255, 0.2);
+    box-shadow: none;
+}
+
+.auth-brand-mark-card img {
+    max-width: 36px;
+    max-height: 36px;
+}
+
+.auth-brand-mark-card i {
+    color: var(--auth-accent);
+    font-size: 1.55rem;
+}
+
 .auth-eyebrow {
     display: inline-flex;
     align-items: center;
@@ -965,6 +993,12 @@ body {
     font-weight: 700;
     color: rgba(255, 255, 255, 0.92);
     background: rgba(255, 255, 255, 0.1);
+}
+
+.auth-eyebrow-card {
+    color: #2453b8;
+    background: rgba(79, 140, 255, 0.12);
+    overflow-wrap: anywhere;
 }
 
 .auth-showcase h1 {
@@ -1132,6 +1166,11 @@ body {
     line-height: 1.55;
 }
 
+.auth-alert ul {
+    font-size: 0.92rem;
+    line-height: 1.55;
+}
+
 .auth-alert-lockout {
     margin-bottom: 24px;
 }
@@ -1162,6 +1201,28 @@ body {
     border-radius: 18px;
     border-color: rgba(148, 163, 184, 0.4);
     background: rgba(255, 255, 255, 0.86);
+}
+
+.auth-password-group .input-group {
+    flex-wrap: nowrap;
+}
+
+.auth-password-group .form-control {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.auth-password-toggle {
+    min-width: 52px;
+    min-height: 60px;
+    border-color: rgba(148, 163, 184, 0.4);
+    color: #475569;
+    border-top-right-radius: 18px;
+    border-bottom-right-radius: 18px;
+}
+
+.auth-password-toggle:focus {
+    box-shadow: 0 0 0 3px rgba(79, 140, 255, 0.15);
 }
 
 .auth-support-row {
@@ -1206,13 +1267,16 @@ body {
 .auth-footer-item {
     display: inline-flex;
     align-items: center;
-    gap: 10px;
-    color: #475569;
-    font-size: 0.9rem;
+    gap: 8px;
+    color: #64748b;
+    font-size: 0.78rem;
+    line-height: 1.45;
 }
 
 .auth-footer-item i {
     color: var(--auth-accent);
+    font-size: 0.85rem;
+    opacity: 0.8;
 }
 
 .auth-lockout-grid {

--- a/backend/static/js/login.js
+++ b/backend/static/js/login.js
@@ -1,0 +1,32 @@
+document.addEventListener("DOMContentLoaded", function () {
+    var toggle = document.querySelector("[data-password-toggle]");
+    if (!toggle) {
+        return;
+    }
+
+    var input = document.getElementById(toggle.dataset.passwordToggle);
+    var icon = toggle.querySelector("i");
+    var label = toggle.querySelector(".visually-hidden");
+    if (!input) {
+        return;
+    }
+
+    toggle.addEventListener("click", function () {
+        var isHidden = input.type === "password";
+        input.type = isHidden ? "text" : "password";
+        toggle.setAttribute("aria-pressed", isHidden ? "true" : "false");
+        toggle.setAttribute(
+            "aria-label",
+            isHidden ? "Sembunyikan kata sandi" : "Tampilkan kata sandi"
+        );
+        if (label) {
+            label.textContent = isHidden
+                ? "Sembunyikan kata sandi"
+                : "Tampilkan kata sandi";
+        }
+        if (icon) {
+            icon.classList.toggle("bi-eye", !isHidden);
+            icon.classList.toggle("bi-eye-slash", isHidden);
+        }
+    });
+});

--- a/backend/templates/registration/login.html
+++ b/backend/templates/registration/login.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags %}
 {% load number_format %}
+{% load static %}
 
 {% block title %}Masuk — Healthcare IMS{% endblock %}
 
@@ -10,57 +11,26 @@
     <div class="auth-orb auth-orb-one"></div>
     <div class="auth-orb auth-orb-two"></div>
 
-    <div class="auth-layout auth-layout-login">
-        <aside class="auth-showcase">
-            <div class="auth-showcase-inner">
-                <div class="auth-brand-mark">
-                    {% if system_settings and system_settings.logo %}
-                    {% with logo_url=system_settings.logo.url|safe_media_url %}
-                    {% if logo_url %}
-                    <img src="{{ logo_url }}" alt="Logo {{ system_settings.facility_name|default:'Healthcare IMS'|escape }}">
-                    {% else %}
-                    <i class="bi bi-hospital"></i>
-                    {% endif %}
-                    {% endwith %}
-                    {% else %}
-                    <i class="bi bi-hospital"></i>
-                    {% endif %}
+    <div class="auth-layout auth-layout-centered">
+        <div class="auth-panel px-3 px-md-0">
+            <div class="auth-card auth-card-login px-4 px-sm-5 py-4 py-sm-5">
+                <div class="auth-card-brand">
+                    <div class="auth-brand-mark auth-brand-mark-card">
+                        {% if system_settings and system_settings.logo %}
+                        {% with logo_url=system_settings.logo.url|safe_media_url %}
+                        {% if logo_url %}
+                        <img src="{{ logo_url }}" alt="Logo {{ system_settings.facility_name|default:'Healthcare IMS'|escape }}">
+                        {% else %}
+                        <i class="bi bi-hospital"></i>
+                        {% endif %}
+                        {% endwith %}
+                        {% else %}
+                        <i class="bi bi-hospital"></i>
+                        {% endif %}
+                    </div>
+                    <span class="auth-eyebrow auth-eyebrow-card">{{ system_settings.platform_label|default:"Healthcare Inventory Platform" }}</span>
                 </div>
 
-                <span class="auth-eyebrow">{{ system_settings.platform_label|default:"Healthcare Inventory Platform" }}</span>
-                <h1>{{ system_settings.facility_name|default:"Healthcare IMS" }}</h1>
-                <p class="auth-showcase-copy">
-                    {{ system_settings.header_title|default:"Sistem Manajemen Inventaris untuk pengelolaan obat dan alat kesehatan." }}
-                </p>
-
-                <div class="auth-feature-list">
-                    <div class="auth-feature-item">
-                        <i class="bi bi-shield-check"></i>
-                        <div>
-                            <strong>Akses terkendali</strong>
-                            <span>Otorisasi berbasis peran dan perlindungan brute-force aktif.</span>
-                        </div>
-                    </div>
-                    <div class="auth-feature-item">
-                        <i class="bi bi-box-seam"></i>
-                        <div>
-                            <strong>Jejak stok terpusat</strong>
-                            <span>Penerimaan, distribusi, recall, dan stok opname tercatat dalam satu alur.</span>
-                        </div>
-                    </div>
-                    <div class="auth-feature-item">
-                        <i class="bi bi-clipboard-data"></i>
-                        <div>
-                            <strong>Siap untuk operasional</strong>
-                            <span>Dirancang untuk gudang farmasi dinas kesehatan dan fasilitas layanan.</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </aside>
-
-        <div class="auth-panel">
-            <div class="auth-card auth-card-login">
                 <div class="auth-card-header">
                     <span class="auth-badge">
                         <i class="bi bi-person-lock"></i>
@@ -75,12 +45,20 @@
                     <i class="bi bi-exclamation-circle"></i>
                     <div>
                         <strong>Autentikasi gagal.</strong>
+                        {% if form.non_field_errors %}
+                        <ul class="mb-0 ps-3">
+                            {% for error in form.non_field_errors %}
+                            <li>{{ error }}</li>
+                            {% endfor %}
+                        </ul>
+                        {% else %}
                         <span>Periksa kembali nama pengguna dan kata sandi Anda.</span>
+                        {% endif %}
                     </div>
                 </div>
                 {% endif %}
 
-                <form method="post" action="{% url 'login' %}" class="auth-form">
+                <form method="post" action="{% url 'login' %}" class="auth-form" autocomplete="off">
                     {% csrf_token %}
                     {% crispy form %}
 
@@ -92,7 +70,7 @@
                     </div>
 
                     <button type="submit" class="btn btn-primary btn-lg auth-submit-btn">
-                        <i class="bi bi-box-arrow-in-right"></i>
+                        <i class="bi bi-box-arrow-in-left"></i>
                         Masuk
                     </button>
                     <input type="hidden" name="next" value="{{ next }}">
@@ -112,4 +90,8 @@
         </div>
     </div>
 </section>
+{% endblock %}
+
+{% block extra_js %}
+<script src="{% static 'js/login.js' %}?v={{ app_version }}-20260724"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Remove the non-form branding panel so the login screen is a single centered card across desktop and mobile viewports.
- Move the logo and platform label into the login card, keep crispy-forms rendering intact, and add an accessible vanilla-JS password visibility toggle.
- De-emphasize login footer notices, swap the submit icon to an inbound login glyph, disable username autocomplete, and render authentication errors in explicit Bootstrap alert styling.

## Root Cause

The previous two-column login template kept a large branding panel beside the login card. That panel made the desktop page visually heavy and contributed to fragile responsive behavior on narrow viewports. The username value observed during QA was browser autofill state rather than a hardcoded template or form value.

## Validation

- `..\scripts\run-django-test.ps1 -Target apps.core.tests.test_core.ErrorPageTemplateTests,apps.core.tests.test_core.LoginLockoutTests -KeepDb -NoActivate`
- `..\scripts\run-django-test.ps1 -Target apps.core.tests -KeepDb -NoActivate` (`112 tests OK`)
- `git diff --check`
- Rendered QA at desktop and 360px mobile: no `auth-showcase` node renders, no horizontal overflow, login inputs/toggle/submit remain at least 44px tall, and the password toggle changes the password input to text without submitting the form.

## Notes

- The repo virtualenv used by the default test helper is missing `whitenoise`, so validation used `-NoActivate` with the working Python environment.
- Chrome may still show saved-credential preview text from the browser profile even though the rendered input has `autocomplete="off"` and an empty DOM value.