### PR TITLE
Add native Docker HEALTHCHECK to backend image (no curl/wget dependency)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,5 +21,10 @@ RUN chmod +x /app/backend/entrypoint.sh
 
 WORKDIR /app/backend
 
+# TCP-level check only (not a full HTTP request) so it doesn't depend on curl/wget being present
+# in the image, or on the request's Host header passing Django's ALLOWED_HOSTS check.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
+    CMD python3 -c "import socket; socket.create_connection(('127.0.0.1', 8000), 2).close()" || exit 1
+
 ENTRYPOINT ["/app/backend/entrypoint.sh"]
 CMD ["gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:8000"]


### PR DESCRIPTION
### Description

Adds a native Docker `HEALTHCHECK` instruction to `backend/Dockerfile`.

### Problem

The image has no `curl`, `wget`, or `nc` — only `python3` and `bash`. Any orchestrator that
generates its own HTTP-based health check by shelling out to `curl`/`wget` (Coolify does this by
default) fails immediately with `curl: not found` / `wget: not found`, regardless of whether the
app itself is healthy.

Separately, even an HTTP-based check that *did* have curl/wget available would likely fail anyway:
a generic health probe typically requests `http://localhost:<port>/` without setting a `Host`
header matching `ALLOWED_HOSTS`, which trips Django's `DisallowedHost` check and returns `400`.

### Fix

A plain TCP-connect check via `python3` (already present in the image), instead of a full HTTP
request:

```dockerfile
HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
    CMD python3 -c "import socket; socket.create_connection(('127.0.0.1', 8000), 2).close()" || exit 1
```

This verifies gunicorn is actually accepting connections on its bind port, without depending on
curl/wget being installed or on the caller sending a specific `Host` header. It's a liveness check
(the process is up and accepting connections), not a full application-logic check — matching what
`HEALTHCHECK` is typically used for.

### Testing

Built the image with this change and ran it standalone against the existing Postgres database:

- Before gunicorn finishes starting: `docker inspect` shows `Health: starting`, healthcheck logs
  show a clean `ConnectionRefusedError` (expected — nothing listening yet)
- Once gunicorn is up: transitions to `Health: healthy` within one check interval
- No changes needed to `ALLOWED_HOSTS` or any other app configuration

### Context

Found this while wiring up Coolify's own application-level health check for a deployment of this
project, which surfaced the missing-curl/wget gap immediately (Coolify's UI can be told to skip its
own probe and just read the container's native `HEALTHCHECK` status instead, but this repo didn't
have one for it to read).
